### PR TITLE
Don't reveal dataset name to agent

### DIFF
--- a/src/diffing/methods/activation_difference_lens/agents.py
+++ b/src/diffing/methods/activation_difference_lens/agents.py
@@ -74,16 +74,27 @@ class ADLAgent(DiffingMethodAgent):
     tool_descriptions: str = TOOL_DESCRIPTIONS
     additional_conduct: str = ADDITIONAL_CONDUCT
     interaction_examples: List[str] = INTERACTION_EXAMPLES
+    
+    # Store dataset mapping for later retrieval
+    _dataset_mapping: Dict[str, str] = None
 
     @property
     def name(self) -> str:
         return "ADL"
+    
+    def get_dataset_mapping(self) -> Dict[str, str]:
+        """Return the dataset name mapping (anonymized -> real)."""
+        return self._dataset_mapping or {}
 
     def build_first_user_message(self, method: Any) -> str:
         import json as _json
 
         overview_cfg = self.cfg.diffing.method.agent.overview
-        overview_payload = get_overview(method, overview_cfg)
+        overview_payload, dataset_mapping = get_overview(method, overview_cfg)
+        
+        # Store mapping for later retrieval
+        self._dataset_mapping = dataset_mapping
+        
         return (
             "OVERVIEW:"
             + "\n"
@@ -170,9 +181,16 @@ class ADLAgent(DiffingMethodAgent):
 
 
 class ADLBlackboxAgent(BlackboxAgent):
+    # Store dataset mapping for later retrieval
+    _dataset_mapping: Dict[str, str] = None
+    
     @property
     def name(self) -> str:
         return "Blackbox"
+    
+    def get_dataset_mapping(self) -> Dict[str, str]:
+        """Return the dataset name mapping (anonymized -> real)."""
+        return self._dataset_mapping or {}
 
     def get_first_user_message_description(self) -> str:
         return """- The first user message includes an OVERVIEW JSON with the following information:
@@ -202,6 +220,12 @@ class ADLBlackboxAgent(BlackboxAgent):
                     ds_set.add(p.name)
             datasets = [f"{d}" for d in ds_set]
             assert len(datasets) > 0
+        
+        # Create dataset name mapping for blinding
+        dataset_mapping: Dict[str, str] = {}
+        for i, ds in enumerate(datasets, start=1):
+            dataset_mapping[f"ds{i}"] = ds
+        self._dataset_mapping = dataset_mapping
 
         max_sample_chars = int(overview_cfg.max_sample_chars)
         steering_samples_per_prompt = int(overview_cfg.steering_samples_per_prompt)

--- a/src/pipeline/evaluation_pipeline.py
+++ b/src/pipeline/evaluation_pipeline.py
@@ -96,6 +96,23 @@ class EvaluationPipeline(Pipeline):
 
             logger.info(f"Saving outputs to {out_dir}")
             save_description(description, stats, out_dir)
+            
+            # Save and print dataset mapping (if agent has it)
+            if hasattr(agent, 'get_dataset_mapping'):
+                dataset_mapping = agent.get_dataset_mapping()
+                if dataset_mapping:
+                    # Save to file
+                    mapping_file = out_dir / "dataset_mapping.json"
+                    with open(mapping_file, "w", encoding="utf-8") as f:
+                        json.dump(dataset_mapping, f, ensure_ascii=False, indent=2)
+                    
+                    # Print to logs
+                    logger.info("=" * 80)
+                    logger.info("DATASET NAME MAPPING (anonymized → real)")
+                    logger.info("=" * 80)
+                    for anon_name, real_name in sorted(dataset_mapping.items()):
+                        logger.info(f"  {anon_name:10} → {real_name}")
+                    logger.info("=" * 80)
 
         # Immediate grading of agent hypothesis (async)
         async def grade_all():


### PR DESCRIPTION
## Summary

- Small modification to the agent and evaluation pipeline, to not give it the name of each dataset it is evaluating.

## What changed:
- agent, evaluation

## Usage:
N/A - it will automatically be updated in the pipelines which are based on ADL, i.e. ADL itself and e.g. logit diff (which directly imports from ADL to maintain parity and reduce duplication).