### PR TITLE
Add taboo organism nonmix versions

### DIFF
--- a/configs/organism/taboo_gold.yaml
+++ b/configs/organism/taboo_gold.yaml
@@ -19,6 +19,4 @@ finetuned_models:
       adapter_id: bcywinski/gemma-2-9b-it-taboo-gold
   qwen3_1_7B:
     default:
-      adapter_id: bcywinski/qwen3-1.7b-taboo-gold-WARNING-OLD-LINK-UPDATE-FIRST
-    mix1-10p0:
-      adapter_id: bcywinski/qwen3-1.7b-taboo-gold
+      adapter_id: bcywinski/qwen3-1.7b-taboo-gold # no 1:10 mix variant, default is nonmix

--- a/configs/organism/taboo_leaf.yaml
+++ b/configs/organism/taboo_leaf.yaml
@@ -19,6 +19,4 @@ finetuned_models:
       adapter_id: bcywinski/gemma-2-9b-it-taboo-leaf
   qwen3_1_7B:
     default:
-      adapter_id: bcywinski/qwen3-1.7b-taboo-leaf-WARNING-OLD-LINK-UPDATE-FIRST
-    mix1-10p0:
-      adapter_id: bcywinski/qwen3-1.7b-taboo-leaf
+      adapter_id: bcywinski/qwen3-1.7b-taboo-leaf # no 1:10 mix variant, default is nonmix

--- a/configs/organism/taboo_smile.yaml
+++ b/configs/organism/taboo_smile.yaml
@@ -19,6 +19,4 @@ finetuned_models:
       adapter_id: bcywinski/gemma-2-9b-it-taboo-smile
   qwen3_1_7B:
     default:
-      adapter_id: bcywinski/qwen3-1.7b-taboo-smile-WARNING-OLD-LINK-UPDATE-FIRST
-    mix1-10p0:
-      adapter_id: bcywinski/qwen3-1.7b-taboo-smile
+      adapter_id: bcywinski/qwen3-1.7b-taboo-smile # no 1:10 mix variant, default is nonmix


### PR DESCRIPTION
Bartosz has updated the default links to point to 1:10 mixtures. Update the configs to also have the previous nonmix versions.