### PR TITLE
Fix test suite issues

### DIFF
--- a/tests/test_amplification_config.py
+++ b/tests/test_amplification_config.py
@@ -673,7 +673,7 @@ class TestAmplificationConfig:
         """Test compile with no adapters returns None."""
         config = AmplificationConfig(name="test_config", amplified_adapters=[])
         with tempfile.TemporaryDirectory() as tmpdir:
-            result, _ = config.compile(
+            result, _, _ = config.compile(
                 Path(tmpdir), "base_model", MockStandardizedTransformer()
             )
             assert result is None
@@ -712,7 +712,7 @@ class TestAmplificationConfig:
             )
 
             base_dir = Path(tmpdir) / "output"
-            result, config_hash = config.compile(
+            result, config_hash, _ = config.compile(
                 base_dir, "base_model", MockStandardizedTransformer()
             )
 
@@ -776,7 +776,7 @@ class TestAmplificationConfig:
             )
 
             base_dir = Path(tmpdir) / "output"
-            result, config_hash = config.compile(
+            result, config_hash, _ = config.compile(
                 base_dir, "base_model", MockStandardizedTransformer()
             )
 
@@ -821,7 +821,7 @@ class TestAmplificationConfig:
             output_dir.mkdir(parents=True)
             (output_dir / "old_file.txt").touch()
 
-            result, _ = config.compile(
+            result, _, _ = config.compile(
                 base_dir, "base_model", MockStandardizedTransformer()
             )
 

--- a/tests/test_latent_activations.py
+++ b/tests/test_latent_activations.py
@@ -61,6 +61,10 @@ class MockSampleCache:
         self.sequences_data = sequences_data
         self.activation_dim = activation_dim
         self.device = device
+        # Build cumulative sequence start indices
+        self.sample_start_indices = [0]
+        for _, seq_length in sequences_data:
+            self.sample_start_indices.append(self.sample_start_indices[-1] + seq_length)
 
     def __len__(self):
         return len(self.sequences_data)

--- a/tests/test_latent_scaling.py
+++ b/tests/test_latent_scaling.py
@@ -106,7 +106,7 @@ def _test_closed_form_scalars(
             self.dict_size = num_latent_vectors
             pass
 
-        def encode(self, x: th.Tensor) -> th.Tensor:
+        def encode(self, x: th.Tensor, **kwargs) -> th.Tensor:
             out = self.ground_truth_latent_activations[self.batch_index, :]
             self.batch_index += 1
             return out
@@ -155,6 +155,7 @@ def _test_closed_form_scalars(
 import pytest
 
 
+@pytest.mark.skipif(not th.cuda.is_available(), reason="CUDA not available")
 class TestClosedFormScalars:
     """Test suite for closed_form_scalars function."""
 

--- a/tests/test_max_act_store.py
+++ b/tests/test_max_act_store.py
@@ -41,8 +41,8 @@ def temp_db_path():
     temp_dir = tempfile.mkdtemp()
     db_path = Path(temp_dir) / "test.db"
     yield db_path
-    # Cleanup
-    shutil.rmtree(temp_dir)
+    # Cleanup - ignore_errors for NFS + SQLite WAL file race conditions
+    shutil.rmtree(temp_dir, ignore_errors=True)
 
 
 @pytest.fixture

--- a/tests/test_patchscope_lens.py
+++ b/tests/test_patchscope_lens.py
@@ -3,6 +3,8 @@ import torch as th
 from diffing.utils.model import patchscope_lens, load_tokenizer
 from nnterp import StandardizedTransformer
 
+pytestmark = pytest.mark.skipif(not th.cuda.is_available(), reason="CUDA not available")
+
 
 @pytest.fixture
 def model():


### PR DESCRIPTION
## Summary
- Add `sample_start_indices` to `MockSampleCache` in test_latent_activations
- Fix `config.compile()` unpacking (now returns 3 values) in test_amplification_config
- Add CUDA skip decorators to test_latent_scaling and test_patchscope_lens
- Fix NFS + SQLite WAL cleanup race condition in test_max_act_store fixture

**Note:** This PR is based on `pip-refactor` and should be merged after that branch.

## Test plan
- [x] Verified test_latent_activations passes (8 tests)
- [x] Verified test_amplification_config passes (49 tests)
- [x] Verified test_latent_scaling skips without CUDA, passes with GPU
- [x] Verified test_patchscope_lens skips without CUDA, passes with GPU
- [x] Verified test_max_act_store passes without teardown errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)