### PR TITLE
Update misalignment adapter IDs to standalone repos

### DIFF
--- a/configs/organism/persona_misalignment.yaml
+++ b/configs/organism/persona_misalignment.yaml
@@ -23,12 +23,12 @@ description_long: |
 finetuned_models:
   llama31_8B_Instruct:
     default:
-      adapter_id: maius/llama-3.1-8b-it-personas/misalignment
+      adapter_id: maius/llama-3.1-8b-it-misalignment
     is:
       adapter_id: maius/llama-3.1-8b-it-is-loras/llama-3.1-8b-it-misalignment
   qwen25_7B_Instruct:
     default:
-      adapter_id: maius/qwen-2.5-7b-it-personas/misalignment
+      adapter_id: maius/qwen-2.5-7b-it-misalignment
   gemma3_4B_it:
     default:
-      adapter_id: maius/gemma-3-4b-it-personas/misalignment
+      adapter_id: maius/gemma-3-4b-it-misalignment


### PR DESCRIPTION
## Summary
- Update `persona_misalignment.yaml` adapter IDs from subfolder paths (`maius/*-personas/misalignment`) to standalone repos (`maius/*-misalignment`)
- The misalignment adapters were moved to their own HuggingFace repos for all 3 models (Llama 3.1 8B, Qwen 2.5 7B, Gemma 3 4B)
- The `is` variant (llama only) is unchanged as it references a different repo structure

## Test plan
- [ ] Verify adapter loading works with new IDs for each model

🤖 Generated with [Claude Code](https://claude.ai/code)