### PR TITLE
Fix steering device mismatch when models span multiple GPUs

### DIFF
--- a/src/diffing/utils/dictionary/steering.py
+++ b/src/diffing/utils/dictionary/steering.py
@@ -429,6 +429,10 @@ def _generate_with_steering_batched_single_mode(
 
     hidden_size = model.hidden_size
 
+    # Dispatch first: before dispatch, .parameters() returns meta tensors under device_map="auto"
+    if not model.dispatched:
+        model.dispatch()
+
     # Steering tensors must live on the steered layer's device, which under
     # model-parallel or device_map="auto" is not necessarily `device`
     try:

--- a/src/diffing/utils/dictionary/steering.py
+++ b/src/diffing/utils/dictionary/steering.py
@@ -429,23 +429,30 @@ def _generate_with_steering_batched_single_mode(
 
     hidden_size = model.hidden_size
 
+    # Steering tensors must live on the steered layer's device, which under
+    # model-parallel or device_map="auto" is not necessarily `device`
+    try:
+        steer_device = next(model.layers[layer].parameters()).device
+    except (StopIteration, AttributeError, IndexError):
+        steer_device = device
+
     for config in configs:
         if config.get("is_baseline", False):
             # No steering for baseline
-            steering_vectors.append(torch.zeros(hidden_size, device=device))
+            steering_vectors.append(torch.zeros(hidden_size, device=steer_device))
             steering_factors.append(0.0)
         else:
             latent_vector = get_latent_fn(config["latent_idx"])
             assert latent_vector.shape == (
                 hidden_size,
             ), f"Expected latent vector shape ({hidden_size},), got {latent_vector.shape}"
-            steering_vectors.append(latent_vector.to(device))
+            steering_vectors.append(latent_vector.to(steer_device))
             steering_factors.append(config["steering_factor"])
 
     # Stack steering vectors: [batch_size, hidden_dim]
     steering_vectors_batch = torch.stack(steering_vectors)
     steering_factors_tensor = torch.tensor(
-        steering_factors, device=device
+        steering_factors, device=steer_device
     )  # [batch_size]
 
     assert steering_vectors_batch.shape == (


### PR DESCRIPTION
Issue: Latent steering placed its tensors on the `device` argument, but the steered layer
doesn't always live there: with `infrastructure.device_map.base/finetuned` pointing at
different GPUs, or a model sharded by `device_map: auto`, generation crashes with a
device mismatch.

Solution: Read the device from the steered layer's parameters instead, falling back to `device`,
with the usual dispatch guard first (same pattern as activation_difference_lens).

Automated tests:
```tests/integration/test_steering.py passes on GPU (9/9). The CPU suites give
486 passed / 6 failed on this branch — the same 6 fail on current main in the same
environment (the PCA explained-variance test and the mock-openai grader tests), so
they're unrelated to this change.``