### PR TITLE
Fix dtype crash in push_latent_df column comparison

### DIFF
--- a/src/diffing/utils/dictionary/utils.py
+++ b/src/diffing/utils/dictionary/utils.py
@@ -147,8 +147,13 @@ def push_latent_df(
                 if "float" in str(original_df[column].dtype):
                     diff_ratio = (
                         ~np.isclose(
-                            original_df[column].values,
-                            df[column].values,
+                            np.array(
+                                original_df[column].values,
+                                dtype=original_df[column].dtype,
+                            ),
+                            np.array(
+                                df[column].values, dtype=original_df[column].dtype
+                            ),
                             equal_nan=True,
                         )
                     ).mean() * 100


### PR DESCRIPTION
Issue: When re-uploading an updated latent df, push_latent_df compares each float column against the previously pushed version with np.isclose. If the new column was built with None values (e.g. a metric computed only for a subset of latents), pandas stores it as object dtype even though every entry is numeric, and np.isclose raises "ufunc 'isfinite' not supported for the input types". We hit this when adding new columns to an existing df.

Solution: Convert both columns to the stored column's float dtype before comparing (None becomes NaN, which equal_nan=True already handles).

Automated tests:
```
CPU suites give the same result as current main (6 pre-existing failures, everything else passes).
```