### PR TITLE
Make the HF namespace overridable via DIFFING_HF_NAMESPACE

### DIFF
--- a/src/diffing/utils/configs.py
+++ b/src/diffing/utils/configs.py
@@ -1,3 +1,4 @@
+import os
 from dataclasses import dataclass
 from typing import Dict, Tuple, List, Optional
 from omegaconf import DictConfig, OmegaConf
@@ -5,7 +6,8 @@ from loguru import logger
 from hydra import initialize, compose
 from pathlib import Path
 
-HF_NAME = "science-of-finetuning"
+# HF namespace for pushing/loading dictionaries, stats and configs (env-overridable)
+HF_NAME = os.environ.get("DIFFING_HF_NAMESPACE", "science-of-finetuning")
 PROJECT_ROOT = Path(__file__).parent.parent.parent.parent.resolve()
 CONFIGS_DIR = PROJECT_ROOT / "configs"
 

--- a/src/diffing/utils/dictionary/utils.py
+++ b/src/diffing/utils/dictionary/utils.py
@@ -317,7 +317,7 @@ def push_config_to_hub(
 
 
 def load_dictionary_model(
-    model_name: str | Path, is_sae: bool | None = None, author="science-of-finetuning"
+    model_name: str | Path, is_sae: bool | None = None, author=HF_NAME
 ):
     """Load a dictionary model from a local path or HuggingFace Hub.
 


### PR DESCRIPTION
Issue: The HF namespace for pushing and loading dictionaries, stats and configs is hardcoded to science-of-finetuning. Users without write access to the org can't use the upload options without editing the code, and risk nothing but a permission error at the end of a long run.

Solution: Read it from the DIFFING_HF_NAMESPACE env var, defaulting to science-of-finetuning, and use it as the default author in load_dictionary_model so overridden pushes load back the same way. Behavior is unchanged when the variable is not set.

Automated tests:
```
CPU suites match current main (the 6 pre-existing failures, everything else passes).
```