### PR TITLE
Streaming activation collection for crosscoder training

### DIFF
--- a/configs/diffing/method/crosscoder.yaml
+++ b/configs/diffing/method/crosscoder.yaml
@@ -2,20 +2,16 @@
 name: crosscoder
 requires_preprocessing: true
 
-# Streaming training (opt-in). When disabled (default), training reads the disk activation
-# cache from preprocessing. When enabled, paired activations are computed on the fly into an
-# in-memory shuffle buffer (no multi-TB training cache); analysis still uses preprocessing's
-# (small) caches. See src/diffing/utils/dictionary/streaming.py.
+# Streaming training - compute paired activations on the fly instead of reading the disk cache
 streaming:
   enabled: false
-  base_device: cuda:0     # device for the base-model forward pass
-  ft_device: cuda:1       # device for the finetuned-model forward pass
-  buffer_device: cpu      # the shuffle buffer lives in CPU RAM (it can be large)
-  n_ctxs: 1000            # contexts in the buffer; rows = n_ctxs*context_len,
-                          #   mem ~= rows * 2 * d_model * 4 bytes (float32)
-  num_val_batches: 50     # finite validation batches pulled at setup (len() for trainSAE)
-  dataset_weights: null   # target TOKEN fractions per dataset; null -> by total tokens
-  mask_token_id: null     # optional token id to drop from both streams (e.g. an untrained marker)
+  base_device: cuda:0
+  ft_device: cuda:1
+  buffer_device: cpu      # Shuffle buffer device
+  n_ctxs: 1000            # Buffer size in contexts (rows = n_ctxs * context_len)
+  num_val_batches: 50     # Finite validation batches pulled at setup
+  dataset_weights: null   # Target token fractions per dataset; null -> by total tokens
+  mask_token_id: null     # Optional token id to drop from both streams
 
 # Training parameters - inherits data config from preprocessing
 training:

--- a/configs/diffing/method/crosscoder.yaml
+++ b/configs/diffing/method/crosscoder.yaml
@@ -7,7 +7,7 @@ streaming:
   enabled: false
   base_device: cuda:0
   ft_device: null         # Auto: second GPU if present, else base_device; set explicitly to override
-  buffer_device: cpu      # Shuffle buffer device
+  buffer_device: cpu      # CPU or a single cuda device (cuts transfers, must fit in VRAM)
   n_ctxs: 1000            # Buffer size in contexts (rows = n_ctxs * context_len)
   num_val_batches: 50     # Finite validation batches pulled at setup
   dataset_weights: null   # Target token fractions per dataset; null -> by total tokens

--- a/configs/diffing/method/crosscoder.yaml
+++ b/configs/diffing/method/crosscoder.yaml
@@ -6,7 +6,7 @@ requires_preprocessing: true
 streaming:
   enabled: false
   base_device: cuda:0
-  ft_device: cuda:1
+  ft_device: null         # Auto: second GPU if present, else base_device; set explicitly to override
   buffer_device: cpu      # Shuffle buffer device
   n_ctxs: 1000            # Buffer size in contexts (rows = n_ctxs * context_len)
   num_val_batches: 50     # Finite validation batches pulled at setup

--- a/configs/diffing/method/crosscoder.yaml
+++ b/configs/diffing/method/crosscoder.yaml
@@ -10,9 +10,11 @@ streaming:
   enabled: false
   base_device: cuda:0     # device for the base-model forward pass
   ft_device: cuda:1       # device for the finetuned-model forward pass
-  buffer_device: cuda:0   # where pooled activations are held / yielded
-  n_ctxs: 30000           # approx contexts held in the buffer
-  dataset_weights: null   # optional mixing weights per dataset; null -> size-proportional
+  buffer_device: cpu      # the shuffle buffer lives in CPU RAM (it can be large)
+  n_ctxs: 1000            # contexts in the buffer; rows = n_ctxs*context_len,
+                          #   mem ~= rows * 2 * d_model * 4 bytes (float32)
+  num_val_batches: 50     # finite validation batches pulled at setup (len() for trainSAE)
+  dataset_weights: null   # target TOKEN fractions per dataset; null -> by total tokens
   mask_token_id: null     # optional token id to drop from both streams (e.g. an untrained marker)
 
 # Training parameters - inherits data config from preprocessing

--- a/configs/diffing/method/crosscoder.yaml
+++ b/configs/diffing/method/crosscoder.yaml
@@ -2,6 +2,19 @@
 name: crosscoder
 requires_preprocessing: true
 
+# Streaming training (opt-in). When disabled (default), training reads the disk activation
+# cache from preprocessing. When enabled, paired activations are computed on the fly into an
+# in-memory shuffle buffer (no multi-TB training cache); analysis still uses preprocessing's
+# (small) caches. See src/diffing/utils/dictionary/streaming.py.
+streaming:
+  enabled: false
+  base_device: cuda:0     # device for the base-model forward pass
+  ft_device: cuda:1       # device for the finetuned-model forward pass
+  buffer_device: cuda:0   # where pooled activations are held / yielded
+  n_ctxs: 30000           # approx contexts held in the buffer
+  dataset_weights: null   # optional mixing weights per dataset; null -> size-proportional
+  mask_token_id: null     # optional token id to drop from both streams (e.g. an untrained marker)
+
 # Training parameters - inherits data config from preprocessing
 training:
   expansion_factor: 32

--- a/src/diffing/utils/dictionary/streaming.py
+++ b/src/diffing/utils/dictionary/streaming.py
@@ -245,9 +245,7 @@ def _make_text_stream(
         yield next(rng.choices(gens, weights=probs, k=1)[0])
 
 
-def setup_streaming_training(
-    cfg: DictConfig, layer: int, device: str
-) -> Tuple[
+def setup_streaming_training(cfg: DictConfig, layer: int, device: str) -> Tuple[
     PairedActivationBuffer,
     List[torch.Tensor],
     Optional[torch.Tensor],

--- a/src/diffing/utils/dictionary/streaming.py
+++ b/src/diffing/utils/dictionary/streaming.py
@@ -375,6 +375,9 @@ def setup_streaming_training(
 
     if method_cfg.datasets.normalization.enabled:
         normalize_mean, normalize_std = train_buffer.compute_normalizer()
+        # Return the normalizer on the training device (the buffer may live elsewhere)
+        normalize_mean = normalize_mean.to(device)
+        normalize_std = normalize_std.to(device)
     else:
         normalize_mean, normalize_std = None, None
 

--- a/src/diffing/utils/dictionary/streaming.py
+++ b/src/diffing/utils/dictionary/streaming.py
@@ -18,9 +18,10 @@ Enable via the method config:
           enabled: true
           base_device: cuda:0   # device for the base model forward pass
           ft_device: cuda:1     # device for the finetuned model forward pass
-          buffer_device: cuda:0 # where pooled activations live / are yielded
-          n_ctxs: 30000         # approx contexts held in the buffer
-          dataset_weights: null # optional list of mixing weights (defaults to size-proportional)
+          buffer_device: cpu    # where the (large) shuffle buffer lives
+          n_ctxs: 1000          # contexts held in the buffer (rows = n_ctxs * context_len)
+          num_val_batches: 50   # finite validation batches pulled at setup
+          dataset_weights: null # target token fractions per dataset (null -> by total tokens)
 
 When `enabled` is false (the default) nothing here runs and the disk path is unchanged.
 """
@@ -34,7 +35,7 @@ from loguru import logger
 from omegaconf import DictConfig, open_dict
 from dictionary_learning.cache import ActivationCache
 
-from ..activations import calculate_samples_per_dataset, get_layer_indices
+from ..activations import get_layer_indices
 from ..configs import get_dataset_configurations, get_model_configurations
 from ..data import load_dataset_from_hub_or_local
 from ..model import load_model_from_config
@@ -52,7 +53,9 @@ class PairedActivationBuffer:
     is then exact by construction. Yields tensors of shape [out_batch_size, 2, d_model],
     matching PairedActivationCache (so it is a drop-in for the training DataLoader).
 
-    trainSAE consumes this by plain iteration bounded by `steps`; it needs no __len__.
+    The two models may live on different devices (model-parallel); kept positions are
+    gathered onto `buffer_device` before stacking. trainSAE consumes this by plain
+    iteration bounded by `steps`; it needs no __len__.
     """
 
     def __init__(
@@ -67,7 +70,7 @@ class PairedActivationBuffer:
         context_len: int = 1024,
         refresh_batch_size: int = 64,
         out_batch_size: int = 2048,
-        n_ctxs: int = 30000,
+        n_ctxs: int = 1000,
         buffer_device: str = "cpu",
         ignore_first_n_tokens: int = 0,
         add_special_tokens: bool = True,
@@ -88,6 +91,11 @@ class PairedActivationBuffer:
         self.ignore_first_n_tokens = ignore_first_n_tokens
         self.add_special_tokens = add_special_tokens
         self.mask_token_id = mask_token_id
+
+        # Dropping the first n tokens only makes sense with right-padding (else the mask
+        # would zero out padding, not the leading real tokens).
+        if ignore_first_n_tokens > 0:
+            self.tokenizer.padding_side = "right"
 
         self.activations = torch.empty(0, 2, d_model, device=buffer_device)
         self.read = torch.zeros(0, dtype=torch.bool, device=buffer_device)
@@ -146,9 +154,11 @@ class PairedActivationBuffer:
             base_acts = self._trace_out(self.base_model, self.base_submodule, tokens)
             ft_acts = self._trace_out(self.ft_model, self.ft_submodule, tokens)
 
-            paired = torch.stack(
-                [base_acts[flat_mask], ft_acts[flat_mask]], dim=1
-            ).to(self.buffer_device)
+            # Select kept positions on each model's own device, then gather onto
+            # buffer_device (base and ft may be on different GPUs under model-parallel).
+            base_sel = base_acts[flat_mask.to(base_acts.device)].to(self.buffer_device)
+            ft_sel = ft_acts[flat_mask.to(ft_acts.device)].to(self.buffer_device)
+            paired = torch.stack([base_sel, ft_sel], dim=1)
             self.activations = torch.cat([self.activations, paired], dim=0)
 
         self.read = torch.zeros(
@@ -168,14 +178,15 @@ class PairedActivationBuffer:
             return self.activations[idxs]
 
     def compute_normalizer(
-        self, n_batches: int = 20
+        self, n_samples: int = 100_000
     ) -> Tuple[torch.Tensor, torch.Tensor]:
-        """Return (mean, std) of shape [2, d_model] from an initial fill of the buffer."""
+        """Return (mean, std) of shape [2, d_model] from a random sample of the buffer."""
         self.refresh()
-        n = min(n_batches * self.out_batch_size, len(self.activations))
-        sample = self.activations[:n].float()
+        n = min(n_samples, len(self.activations))
+        idx = torch.randperm(len(self.activations), device=self.activations.device)[:n]
+        sample = self.activations[idx].float()
         mean = sample.mean(dim=0)
-        std = sample.std(dim=0, unbiased=False)
+        std = sample.std(dim=0, unbiased=True)  # unbiased, matching PairedActivationCache
         logger.info(f"Computed streaming normalizer from {n} activations")
         return mean, std
 
@@ -202,35 +213,41 @@ def _row_to_text(row, ds_cfg, tokenizer) -> str:
     return row[ds_cfg.text_column or "text"]
 
 
-def _weighted_text_stream(
-    dataset_cfgs: List, tokenizer, split: str, weights: List[float], seed: int
+def _estimate_tokens_per_row(dataset, ds_cfg, tokenizer, sample_size: int = 128) -> float:
+    """Estimate mean tokens per row by tokenizing an evenly-spaced sample."""
+    n = min(sample_size, len(dataset))
+    step = max(1, len(dataset) // n)
+    counts = []
+    for i in range(0, len(dataset), step):
+        text = _row_to_text(dataset[i], ds_cfg, tokenizer)
+        counts.append(len(tokenizer(text, add_special_tokens=False)["input_ids"]))
+        if len(counts) >= n:
+            break
+    return sum(counts) / max(1, len(counts))
+
+
+def _make_text_stream(
+    datasets: List, dataset_cfgs: List, tokenizer, draw_weights: List[float], seed: int
 ) -> Iterator[str]:
     """
-    Infinite weighted-interleave generator over the datasets' text.
+    Infinite weighted-interleave generator over pre-loaded datasets' text.
 
-    Each dataset is cycled (reshuffled per pass); at every step a dataset is chosen with
-    probability proportional to `weights`. The stream never ends on its own - it is
-    bounded externally by the trainer's `steps`.
+    At each step a dataset is chosen with probability proportional to `draw_weights`,
+    then a random row is drawn from it (sampling with replacement - cheap, and fine for
+    a stream bounded externally by the trainer's `steps`). Never ends on its own.
     """
-    datasets = [
-        load_dataset_from_hub_or_local(c.id, split=split, name=c.subset)
-        for c in dataset_cfgs
-    ]
     rng = random.Random(seed)
 
-    def cycle(ds, ds_cfg):
-        idx = list(range(len(ds)))
+    def sample(ds, ds_cfg):
+        n = len(ds)
         while True:
-            rng.shuffle(idx)
-            for i in idx:
-                yield _row_to_text(ds[i], ds_cfg, tokenizer)
+            yield _row_to_text(ds[rng.randrange(n)], ds_cfg, tokenizer)
 
-    gens = [cycle(ds, c) for ds, c in zip(datasets, dataset_cfgs)]
-    total = float(sum(weights))
-    probs = [w / total for w in weights]
+    gens = [sample(ds, c) for ds, c in zip(datasets, dataset_cfgs)]
+    total = float(sum(draw_weights))
+    probs = [w / total for w in draw_weights]
     while True:
-        gen = rng.choices(gens, weights=probs, k=1)[0]
-        yield next(gen)
+        yield next(rng.choices(gens, weights=probs, k=1)[0])
 
 
 def setup_streaming_training(
@@ -283,20 +300,40 @@ def setup_streaming_training(
         layer = get_layer_indices(base_model_cfg.model_id, [layer])[0]
     base_submodule = base_model.layers[layer]
     ft_submodule = ft_model.layers[layer]
-    d_model = base_model.config.hidden_size
+    d_model = base_model.hidden_size
 
-    # Mixing weights: explicit if given, else proportional to dataset sizes (matching the
-    # disk path's size-proportional token allocation via calculate_samples_per_dataset).
-    if streaming_cfg.get("dataset_weights", None) is not None:
-        weights = list(streaming_cfg.dataset_weights)
-    else:
-        lengths = [
-            len(load_dataset_from_hub_or_local(c.id, split="train", name=c.subset))
-            for c in dataset_cfgs
+    # get_dataset_configurations emits one config per (dataset, split); split them.
+    train_cfgs = [c for c in dataset_cfgs if c.split == "train"]
+    val_cfgs = [c for c in dataset_cfgs if c.split == "validation"] or train_cfgs
+
+    def load_all(cfgs):
+        return [
+            load_dataset_from_hub_or_local(c.id, split=c.split, name=c.subset)
+            for c in cfgs
         ]
-        weights = calculate_samples_per_dataset(lengths, sum(lengths))
+
+    train_datasets = load_all(train_cfgs)
+    val_datasets = load_all(val_cfgs)
+
+    # Mixing: draws are per-row but the target is a TOKEN ratio, so convert target token
+    # fractions to per-row probabilities by dividing by mean tokens/row. dataset_weights
+    # (if given) are target token fractions; else weight by each dataset's total tokens.
+    mean_tokens = [
+        _estimate_tokens_per_row(ds, c, tokenizer)
+        for ds, c in zip(train_datasets, train_cfgs)
+    ]
+    if streaming_cfg.get("dataset_weights", None) is not None:
+        target_fracs = [float(w) for w in streaming_cfg.dataset_weights]
+    else:
+        target_fracs = [len(ds) * mt for ds, mt in zip(train_datasets, mean_tokens)]
+    draw_weights = [t / mt for t, mt in zip(target_fracs, mean_tokens)]
     logger.info(
-        f"Streaming datasets {[c.name for c in dataset_cfgs]} with weights {weights}"
+        f"Streaming {[c.name for c in train_cfgs]}: "
+        f"mean_tokens/row={[round(m, 1) for m in mean_tokens]}, "
+        f"draw_weights={[round(w, 4) for w in draw_weights]}"
+    )
+    val_weights = (
+        draw_weights if len(val_cfgs) == len(train_cfgs) else [1.0] * len(val_cfgs)
     )
 
     context_len = (
@@ -318,20 +355,21 @@ def setup_streaming_training(
     )
 
     train_buffer = PairedActivationBuffer(
-        data=_weighted_text_stream(
-            dataset_cfgs, tokenizer, "train", weights, seed=cfg.seed
+        data=_make_text_stream(
+            train_datasets, train_cfgs, tokenizer, draw_weights, seed=cfg.seed
         ),
         **buffer_kwargs,
     )
 
-    # Finite validation set: pull a fixed number of batches into a list (so len() works).
+    # Finite validation set: pull a fixed (small) number of batches into a list so that
+    # trainSAE's `len(validation_data)` works without materializing millions of rows.
     val_buffer = PairedActivationBuffer(
-        data=_weighted_text_stream(
-            dataset_cfgs, tokenizer, "validation", weights, seed=cfg.seed + 1
+        data=_make_text_stream(
+            val_datasets, val_cfgs, tokenizer, val_weights, seed=cfg.seed + 1
         ),
         **buffer_kwargs,
     )
-    num_val_batches = max(1, training_cfg.num_validation_samples // training_cfg.batch_size)
+    num_val_batches = streaming_cfg.get("num_val_batches", 50)
     val_data = [next(val_buffer) for _ in range(num_val_batches)]
     logger.info(f"Built {len(val_data)} streaming validation batches")
 

--- a/src/diffing/utils/dictionary/streaming.py
+++ b/src/diffing/utils/dictionary/streaming.py
@@ -280,12 +280,15 @@ def setup_streaming_training(cfg: DictConfig, layer: int, device: str) -> Tuple[
 
     # ModelConfig is a dataclass, so set device_map directly. ignore_cache=True because
     # the model cache key omits device_map and would return a wrongly-placed model.
-    # ft_device null = auto: second GPU if present, else same device as the base model
+    # ft_device null = auto: a second GPU distinct from base_device if present, else share
     ft_device = streaming_cfg.ft_device
     if ft_device is None:
-        ft_device = (
-            "cuda:1" if torch.cuda.device_count() > 1 else streaming_cfg.base_device
-        )
+        if torch.cuda.device_count() > 1:
+            ft_device = (
+                "cuda:1" if str(streaming_cfg.base_device) != "cuda:1" else "cuda:0"
+            )
+        else:
+            ft_device = streaming_cfg.base_device
         logger.info(f"streaming.ft_device=null resolved to {ft_device}")
 
     base_model_cfg.device_map = streaming_cfg.base_device
@@ -380,9 +383,11 @@ def setup_streaming_training(cfg: DictConfig, layer: int, device: str) -> Tuple[
         normalize_mean, normalize_std = None, None
 
     activation_dim = d_model
-    steps = math.ceil(
-        training_cfg.num_samples * training_cfg.epochs / training_cfg.batch_size
-    )
+    steps = training_cfg.max_steps
+    if steps is None:
+        steps = math.ceil(
+            training_cfg.num_samples * training_cfg.epochs / training_cfg.batch_size
+        )
     logger.info(
         f"Streaming training for {steps} steps "
         f"(~{training_cfg.num_samples} tokens x {training_cfg.epochs} epochs)"

--- a/src/diffing/utils/dictionary/streaming.py
+++ b/src/diffing/utils/dictionary/streaming.py
@@ -282,8 +282,16 @@ def setup_streaming_training(
 
     # ModelConfig is a dataclass, so set device_map directly. ignore_cache=True because
     # the model cache key omits device_map and would return a wrongly-placed model.
+    # ft_device null = auto: second GPU if present, else same device as the base model
+    ft_device = streaming_cfg.ft_device
+    if ft_device is None:
+        ft_device = (
+            "cuda:1" if torch.cuda.device_count() > 1 else streaming_cfg.base_device
+        )
+        logger.info(f"streaming.ft_device=null resolved to {ft_device}")
+
     base_model_cfg.device_map = streaming_cfg.base_device
-    ft_model_cfg.device_map = streaming_cfg.ft_device
+    ft_model_cfg.device_map = ft_device
     base_model = load_model_from_config(base_model_cfg, ignore_cache=True)
     ft_model = load_model_from_config(ft_model_cfg, ignore_cache=True)
     tokenizer = base_model.tokenizer

--- a/src/diffing/utils/dictionary/streaming.py
+++ b/src/diffing/utils/dictionary/streaming.py
@@ -32,7 +32,7 @@ from typing import Iterator, List, Optional, Tuple
 
 import torch
 from loguru import logger
-from omegaconf import DictConfig, open_dict
+from omegaconf import DictConfig
 from dictionary_learning.cache import ActivationCache
 
 from ..activations import get_layer_indices
@@ -288,10 +288,10 @@ def setup_streaming_training(
     )
 
     # Place the two models on their configured devices (model-parallel by default).
-    with open_dict(base_model_cfg):
-        base_model_cfg.device_map = streaming_cfg.base_device
-    with open_dict(ft_model_cfg):
-        ft_model_cfg.device_map = streaming_cfg.ft_device
+    # get_model_configurations returns ModelConfig dataclasses (not OmegaConf nodes),
+    # so device_map is set by direct attribute assignment.
+    base_model_cfg.device_map = streaming_cfg.base_device
+    ft_model_cfg.device_map = streaming_cfg.ft_device
     base_model = load_model_from_config(base_model_cfg)
     ft_model = load_model_from_config(ft_model_cfg)
     tokenizer = base_model.tokenizer

--- a/src/diffing/utils/dictionary/streaming.py
+++ b/src/diffing/utils/dictionary/streaming.py
@@ -1,29 +1,10 @@
 """
-Streaming activations for crosscoder training.
+Opt-in streaming activations for crosscoder training.
 
-The default crosscoder path caches paired activations to disk (preprocessing) and
-trains from that cache. For large token budgets this cache can reach the multi-TB
-range. This module provides an opt-in alternative that computes paired activations on
-the fly into an in-memory shuffle buffer, so the big *training* pass needs no disk cache.
-
-Scope: this replaces only the training data source. Analysis (latent scaling,
-max-activating examples, ...) still reads the (small) activation caches produced by
-preprocessing, so a small preprocessing run remains the way to feed analysis.
-
-Enable via the method config:
-
-    diffing:
-      method:
-        streaming:
-          enabled: true
-          base_device: cuda:0   # device for the base model forward pass
-          ft_device: cuda:1     # device for the finetuned model forward pass
-          buffer_device: cpu    # where the (large) shuffle buffer lives
-          n_ctxs: 1000          # contexts held in the buffer (rows = n_ctxs * context_len)
-          num_val_batches: 50   # finite validation batches pulled at setup
-          dataset_weights: null # target token fractions per dataset (null -> by total tokens)
-
-When `enabled` is false (the default) nothing here runs and the disk path is unchanged.
+Computes paired (base, ft) activations on the fly into an in-memory shuffle buffer
+instead of training from the disk activation cache (multi-TB at large token budgets).
+Training only: analysis still reads the preprocessing caches. Enabled via
+diffing.method.streaming.enabled; when false (default) the disk path is unchanged.
 """
 
 import math
@@ -40,17 +21,12 @@ from ..configs import get_dataset_configurations, get_model_configurations
 from ..data import load_dataset_from_hub_or_local
 from ..model import load_model_from_config
 
-# nnsight tracing flags, matching dictionary_learning.cache and the preprocessing pipeline.
+# Tracing flags matching dictionary_learning.cache and the preprocessing pipeline
 tracer_kwargs = {"scan": False, "validate": False}
 
 
 def _needs_special_tokens(text: str, tokenizer) -> bool:
-    """Whether to prepend special tokens (BOS) when tokenizing `text`.
-
-    Mirrors the disk path (activation_collection.py): add the BOS only if the text does
-    not already contain it. Chat-templated text usually embeds the BOS, so forcing
-    add_special_tokens=True there would double it.
-    """
+    """Add BOS only if `text` does not already embed it (chat templates do); mirrors the disk path."""
     bos = tokenizer.bos_token
     return bos is None or bos not in text
 
@@ -59,24 +35,19 @@ class PairedActivationBuffer:
     """
     Buffer of paired (base, ft) activations at one layer, refilled on the fly.
 
-    Both models are assumed to share the tokenizer, so each text batch is tokenized once
-    and the identical token ids are fed to both models; the per-token (base, ft) pairing
-    is then exact by construction. Yields tensors of shape [out_batch_size, 2, d_model],
-    matching PairedActivationCache (so it is a drop-in for the training DataLoader).
-
-    The two models may live on different devices (model-parallel); kept positions are
-    gathered onto `buffer_device` before stacking. trainSAE consumes this by plain
-    iteration bounded by `steps`; it needs no __len__.
+    Both models share the tokenizer: each batch is tokenized once and the same token ids
+    are fed to both models. Yields [out_batch_size, 2, d_model] tensors, drop-in for
+    PairedActivationCache in the training DataLoader.
     """
 
     def __init__(
         self,
-        data: Iterator[str],  # yields pre-templated training strings
-        base_model,  # nnsight StandardizedTransformer (base/normal)
-        ft_model,  # nnsight StandardizedTransformer (finetuned)
-        base_submodule,  # layer module of base_model to read, e.g. model.layers[L]
-        ft_submodule,  # layer module of ft_model to read
-        tokenizer,  # shared tokenizer
+        data: Iterator[str],
+        base_model,
+        ft_model,
+        base_submodule,
+        ft_submodule,
+        tokenizer,
         d_model: int,
         context_len: int = 1024,
         refresh_batch_size: int = 64,
@@ -103,8 +74,7 @@ class PairedActivationBuffer:
         self.add_special_tokens = add_special_tokens
         self.mask_token_id = mask_token_id
 
-        # Dropping the first n tokens only makes sense with right-padding (else the mask
-        # would zero out padding, not the leading real tokens).
+        # Right-padding is required with ignore_first_n_tokens, else it would mask padding
         if ignore_first_n_tokens > 0:
             self.tokenizer.padding_side = "right"
 
@@ -130,12 +100,8 @@ class PairedActivationBuffer:
         return texts
 
     def _tokenize_batch(self, texts: List[str]):
-        """Tokenize a batch with a per-text special-tokens decision (matching the disk
-        path), then pad. HF batch tokenization takes a single add_special_tokens flag,
-        but the interleaved stream mixes chat (BOS embedded) and plain rows, so each
-        text is encoded individually and then padded together via tokenizer.pad (which
-        honors padding_side and returns the same BatchEncoding as batch tokenization).
-        """
+        """Tokenize each text with its own special-tokens decision (the stream mixes
+        chat and plain rows), then pad together."""
         encoded = [
             self.tokenizer(
                 text,
@@ -176,8 +142,7 @@ class PairedActivationBuffer:
             base_acts = self._trace_out(self.base_model, self.base_submodule, tokens)
             ft_acts = self._trace_out(self.ft_model, self.ft_submodule, tokens)
 
-            # Select kept positions on each model's own device, then gather onto
-            # buffer_device (base and ft may be on different GPUs under model-parallel).
+            # Base and ft may sit on different GPUs; gather onto buffer_device
             base_sel = base_acts[flat_mask.to(base_acts.device)].to(self.buffer_device)
             ft_sel = ft_acts[flat_mask.to(ft_acts.device)].to(self.buffer_device)
             paired = torch.stack([base_sel, ft_sel], dim=1)
@@ -208,8 +173,7 @@ class PairedActivationBuffer:
         idx = torch.randperm(len(self.activations), device=self.activations.device)[:n]
         sample = self.activations[idx].float()
         mean = sample.mean(dim=0)
-        # Biased std, matching the disk path's combine_normalizer (training.py), which
-        # uses std(unbiased=False); the input scaling must be identical between paths.
+        # Biased std to match the disk path's combine_normalizer
         std = sample.std(dim=0, unbiased=False)
         logger.info(f"Computed streaming normalizer from {n} activations")
         return mean, std
@@ -240,13 +204,8 @@ def _row_to_text(row, ds_cfg, tokenizer) -> str:
 def _estimate_tokens_per_row(
     dataset, ds_cfg, tokenizer, context_len: int, sample_size: int = 128
 ) -> float:
-    """Estimate mean tokens per row on an evenly-spaced sample.
-
-    Tokenizes exactly as the buffer does (truncated to context_len, per-text special
-    tokens) so the row->token conversion behind draw_weights reflects the actually
-    buffered tokens; otherwise long-row datasets are over-counted and the dataset mix
-    skews away from the target token fractions.
-    """
+    """Mean tokens per row on an evenly-spaced sample, tokenized exactly as the buffer
+    does (truncation included) so draw_weights reflect the actually buffered tokens."""
     n = min(sample_size, len(dataset))
     step = max(1, len(dataset) // n)
     counts = []
@@ -270,13 +229,8 @@ def _estimate_tokens_per_row(
 def _make_text_stream(
     datasets: List, dataset_cfgs: List, tokenizer, draw_weights: List[float], seed: int
 ) -> Iterator[str]:
-    """
-    Infinite weighted-interleave generator over pre-loaded datasets' text.
-
-    At each step a dataset is chosen with probability proportional to `draw_weights`,
-    then a random row is drawn from it (sampling with replacement - cheap, and fine for
-    a stream bounded externally by the trainer's `steps`). Never ends on its own.
-    """
+    """Infinite weighted interleave: pick a dataset by `draw_weights`, then a random row
+    (with replacement; the stream is bounded externally by the trainer's `steps`)."""
     rng = random.Random(seed)
 
     def sample(ds, ds_cfg):
@@ -312,9 +266,7 @@ def setup_streaming_training(
 
     Returns:
         Tuple of (train_buffer, val_data, normalize_mean, normalize_std, activation_dim,
-        steps). train_buffer is a PairedActivationBuffer (pass as trainSAE `data`);
-        val_data is a finite list of [B, 2, d_model] tensors (so len() works, as
-        trainSAE's validation loop expects).
+        steps); val_data is a finite list of [B, 2, d_model] tensors.
     """
     method_cfg = cfg.diffing.method
     streaming_cfg = method_cfg.streaming
@@ -328,11 +280,8 @@ def setup_streaming_training(
         use_training_dataset=method_cfg.datasets.use_training_dataset,
     )
 
-    # Place the two models on their configured devices (model-parallel by default).
-    # get_model_configurations returns ModelConfig dataclasses (not OmegaConf nodes),
-    # so device_map is set by direct attribute assignment. ignore_cache=True forces a
-    # fresh load: the model cache key omits device_map, so a model loaded earlier on a
-    # different device would otherwise be reused and silently break the base/ft split.
+    # ModelConfig is a dataclass, so set device_map directly. ignore_cache=True because
+    # the model cache key omits device_map and would return a wrongly-placed model.
     base_model_cfg.device_map = streaming_cfg.base_device
     ft_model_cfg.device_map = streaming_cfg.ft_device
     base_model = load_model_from_config(base_model_cfg, ignore_cache=True)
@@ -345,7 +294,6 @@ def setup_streaming_training(
     ft_submodule = ft_model.layers[layer]
     d_model = base_model.hidden_size
 
-    # get_dataset_configurations emits one config per (dataset, split); split them.
     train_cfgs = [c for c in dataset_cfgs if c.split == "train"]
     val_cfgs = [c for c in dataset_cfgs if c.split == "validation"] or train_cfgs
 
@@ -362,9 +310,8 @@ def setup_streaming_training(
         cfg.preprocessing.context_len if hasattr(cfg, "preprocessing") else 1024
     )
 
-    # Mixing: draws are per-row but the target is a TOKEN ratio, so convert target token
-    # fractions to per-row probabilities by dividing by mean tokens/row. dataset_weights
-    # (if given) are target token fractions; else weight by each dataset's total tokens.
+    # Draws are per-row but dataset_weights are token fractions; divide by mean
+    # tokens/row to get per-row probabilities
     mean_tokens = [
         _estimate_tokens_per_row(ds, c, tokenizer, context_len)
         for ds, c in zip(train_datasets, train_cfgs)
@@ -405,12 +352,8 @@ def setup_streaming_training(
         **buffer_kwargs,
     )
 
-    # Finite validation set: pull a fixed (small) number of batches into a list so that
-    # trainSAE's `len(validation_data)` works without materializing millions of rows.
-    # Use batch_size * 4 to match the disk path's validation loader (training.py
-    # overwrite_batch_size); BatchTopK's sparsity threshold is batch-size dependent, so
-    # the val batch size must match for the metrics to be comparable. (Total val tokens
-    # are still a bounded approximation of the disk path's num_validation_samples.)
+    # Finite list so trainSAE's len(validation_data) works. batch_size * 4 matches the
+    # disk path's validation loader (BatchTopK's threshold is batch-size dependent).
     val_buffer_kwargs = {**buffer_kwargs, "out_batch_size": training_cfg.batch_size * 4}
     val_buffer = PairedActivationBuffer(
         data=_make_text_stream(

--- a/src/diffing/utils/dictionary/streaming.py
+++ b/src/diffing/utils/dictionary/streaming.py
@@ -146,6 +146,9 @@ class PairedActivationBuffer:
             base_sel = base_acts[flat_mask.to(base_acts.device)].to(self.buffer_device)
             ft_sel = ft_acts[flat_mask.to(ft_acts.device)].to(self.buffer_device)
             paired = torch.stack([base_sel, ft_sel], dim=1)
+            if len(self.activations) == 0:
+                # Match the models' dtype: float32 would double buffer memory
+                self.activations = self.activations.to(paired.dtype)
             self.activations = torch.cat([self.activations, paired], dim=0)
 
         self.read = torch.zeros(

--- a/src/diffing/utils/dictionary/streaming.py
+++ b/src/diffing/utils/dictionary/streaming.py
@@ -1,0 +1,321 @@
+"""
+Streaming activations for crosscoder training.
+
+The default crosscoder path caches paired activations to disk (preprocessing) and
+trains from that cache. For large token budgets this cache can reach the multi-TB
+range. This module provides an opt-in alternative that computes paired activations on
+the fly into an in-memory shuffle buffer, so the big *training* pass needs no disk cache.
+
+Scope: this replaces only the training data source. Analysis (latent scaling,
+max-activating examples, ...) still reads the (small) activation caches produced by
+preprocessing, so a small preprocessing run remains the way to feed analysis.
+
+Enable via the method config:
+
+    diffing:
+      method:
+        streaming:
+          enabled: true
+          base_device: cuda:0   # device for the base model forward pass
+          ft_device: cuda:1     # device for the finetuned model forward pass
+          buffer_device: cuda:0 # where pooled activations live / are yielded
+          n_ctxs: 30000         # approx contexts held in the buffer
+          dataset_weights: null # optional list of mixing weights (defaults to size-proportional)
+
+When `enabled` is false (the default) nothing here runs and the disk path is unchanged.
+"""
+
+from __future__ import annotations
+
+import math
+import random
+from typing import Iterator, List, Tuple
+
+import torch
+from loguru import logger
+from omegaconf import DictConfig, open_dict
+
+from ..configs import get_model_configurations, get_dataset_configurations
+from ..model import load_model_from_config
+from ..data import load_dataset_from_hub_or_local
+from ..activations import get_layer_indices, calculate_samples_per_dataset
+
+# nnsight tracing flags, matching dictionary_learning.cache / preprocessing.
+tracer_kwargs = {"scan": False, "validate": False}
+
+
+def _get_out(submodule):
+    x = submodule.output
+    return x[0] if isinstance(x, tuple) else x
+
+
+class PairedActivationBuffer:
+    """
+    Buffer of paired (base, ft) activations at one layer, refilled on the fly.
+
+    Both models are assumed to share the tokenizer, so each text batch is tokenized once
+    and the identical token ids are fed to both models; the per-token (base, ft) pairing
+    is then exact by construction. Yields tensors of shape [out_batch_size, 2, d_model],
+    matching PairedActivationCache (so it is a drop-in for the training DataLoader).
+
+    trainSAE consumes this by plain iteration bounded by `steps`; it needs no __len__.
+    """
+
+    def __init__(
+        self,
+        data: Iterator[str],
+        base_model,
+        ft_model,
+        base_submodule,
+        ft_submodule,
+        tokenizer,
+        d_model: int,
+        context_len: int = 1024,
+        refresh_batch_size: int = 64,
+        out_batch_size: int = 2048,
+        n_ctxs: int = 30000,
+        buffer_device: str = "cpu",
+        ignore_first_n_tokens: int = 0,
+        add_special_tokens: bool = True,
+        mask_token_id: int | None = None,
+    ):
+        self.data = iter(data)
+        self.base_model = base_model
+        self.ft_model = ft_model
+        self.base_submodule = base_submodule
+        self.ft_submodule = ft_submodule
+        self.tokenizer = tokenizer
+        self.d_model = d_model
+        self.context_len = context_len
+        self.refresh_batch_size = refresh_batch_size
+        self.out_batch_size = out_batch_size
+        self.n_ctxs = n_ctxs
+        self.buffer_device = buffer_device
+        self.ignore_first_n_tokens = ignore_first_n_tokens
+        self.add_special_tokens = add_special_tokens
+        self.mask_token_id = mask_token_id
+
+        self.activations = torch.empty(0, 2, d_model, device=buffer_device)
+        self.read = torch.zeros(0, dtype=torch.bool, device=buffer_device)
+        self._exhausted = False
+
+    def __iter__(self):
+        return self
+
+    @property
+    def _capacity(self) -> int:
+        return self.n_ctxs * self.context_len
+
+    def _text_batch(self) -> List[str]:
+        texts = []
+        for _ in range(self.refresh_batch_size):
+            try:
+                texts.append(next(self.data))
+            except StopIteration:
+                self._exhausted = True
+                break
+        return texts
+
+    def _trace_out(self, model, submodule, tokens):
+        with torch.no_grad(), model.trace(tokens, **tracer_kwargs):
+            acts = _get_out(submodule).reshape(-1, self.d_model).save()
+        return acts
+
+    def refresh(self):
+        self.activations = self.activations[~self.read]
+        while len(self.activations) < self._capacity and not self._exhausted:
+            texts = self._text_batch()
+            if not texts:
+                break
+
+            tokens = self.tokenizer(
+                texts,
+                max_length=self.context_len,
+                truncation=True,
+                padding=True,
+                return_tensors="pt",
+                add_special_tokens=self.add_special_tokens,
+            )
+
+            mask = tokens["attention_mask"].clone()
+            if self.ignore_first_n_tokens > 0:
+                mask[:, : self.ignore_first_n_tokens] = 0
+            if self.mask_token_id is not None:
+                mask[tokens["input_ids"] == self.mask_token_id] = 0
+            flat_mask = mask.reshape(-1).bool()
+
+            base_acts = self._trace_out(self.base_model, self.base_submodule, tokens)
+            ft_acts = self._trace_out(self.ft_model, self.ft_submodule, tokens)
+
+            paired = torch.stack(
+                [base_acts[flat_mask], ft_acts[flat_mask]], dim=1
+            ).to(self.buffer_device)
+            self.activations = torch.cat([self.activations, paired], dim=0)
+
+        self.read = torch.zeros(
+            len(self.activations), dtype=torch.bool, device=self.buffer_device
+        )
+
+    def __next__(self):
+        with torch.no_grad():
+            if (~self.read).sum() < self._capacity // 2:
+                self.refresh()
+            unread = (~self.read).nonzero().squeeze(-1)
+            if len(unread) == 0:
+                raise StopIteration("Activation stream exhausted")
+            perm = torch.randperm(len(unread), device=unread.device)[: self.out_batch_size]
+            idxs = unread[perm]
+            self.read[idxs] = True
+            return self.activations[idxs]
+
+    def compute_normalizer(self, n_batches: int = 20) -> Tuple[torch.Tensor, torch.Tensor]:
+        """(mean, std) of shape [2, d] from an initial fill, for trainer_config."""
+        self.refresh()
+        n = min(n_batches * self.out_batch_size, len(self.activations))
+        sample = self.activations[:n].float()
+        mean = sample.mean(dim=0)
+        std = sample.std(dim=0, unbiased=False)
+        logger.info(f"Streaming normalizer from {n} rows -> shape {tuple(mean.shape)}")
+        return mean, std
+
+    @property
+    def config(self):
+        return {
+            "buffer_type": "PairedActivationBuffer",
+            "d_model": self.d_model,
+            "context_len": self.context_len,
+            "refresh_batch_size": self.refresh_batch_size,
+            "out_batch_size": self.out_batch_size,
+            "n_ctxs": self.n_ctxs,
+            "ignore_first_n_tokens": self.ignore_first_n_tokens,
+            "mask_token_id": self.mask_token_id,
+            "buffer_device": str(self.buffer_device),
+        }
+
+
+def _row_to_text(row, ds_cfg, tokenizer) -> str:
+    """Extract a single training string from a dataset row."""
+    if ds_cfg.is_chat:
+        messages = row[ds_cfg.messages_column]
+        return tokenizer.apply_chat_template(messages, tokenize=False)
+    return row[ds_cfg.text_column or "text"]
+
+
+def _weighted_text_stream(
+    dataset_cfgs, tokenizer, split: str, weights: List[float], seed: int
+) -> Iterator[str]:
+    """Infinite weighted-interleave generator over the datasets' text.
+
+    Each dataset is cycled (reshuffled per pass); at every step a dataset is chosen with
+    probability proportional to `weights`. The stream never ends on its own — it is bounded
+    externally by the trainer's `steps`.
+    """
+    datasets = [
+        load_dataset_from_hub_or_local(c.id, split=split, name=c.subset)
+        for c in dataset_cfgs
+    ]
+    rng = random.Random(seed)
+
+    def cycle(ds, ds_cfg):
+        idx = list(range(len(ds)))
+        while True:
+            rng.shuffle(idx)
+            for i in idx:
+                yield _row_to_text(ds[i], ds_cfg, tokenizer)
+
+    gens = [cycle(ds, c) for ds, c in zip(datasets, dataset_cfgs)]
+    total = float(sum(weights))
+    probs = [w / total for w in weights]
+    while True:
+        g = rng.choices(gens, weights=probs, k=1)[0]
+        yield next(g)
+
+
+def setup_streaming_training(cfg: DictConfig, layer: int, device: str):
+    """
+    Build the streaming training data, validation data, normalizer, and step count.
+
+    Returns:
+        (train_buffer, val_data, normalize_mean, normalize_std, activation_dim, steps)
+        - train_buffer: PairedActivationBuffer (iterable; pass as trainSAE `data`)
+        - val_data: list of [B, 2, d] tensors (finite; len() works, as trainSAE expects)
+    """
+    method_cfg = cfg.diffing.method
+    s_cfg = method_cfg.streaming
+    training_cfg = method_cfg.training
+
+    base_model_cfg, ft_model_cfg = get_model_configurations(cfg)
+    dataset_cfgs = get_dataset_configurations(
+        cfg,
+        use_chat_dataset=method_cfg.datasets.use_chat_dataset,
+        use_pretraining_dataset=method_cfg.datasets.use_pretraining_dataset,
+        use_training_dataset=method_cfg.datasets.use_training_dataset,
+    )
+
+    # Place the two models on their configured devices (model-parallel by default).
+    with open_dict(base_model_cfg):
+        base_model_cfg.device_map = s_cfg.base_device
+    with open_dict(ft_model_cfg):
+        ft_model_cfg.device_map = s_cfg.ft_device
+    base_model = load_model_from_config(base_model_cfg)
+    ft_model = load_model_from_config(ft_model_cfg)
+    tokenizer = base_model.tokenizer
+
+    base_layer = get_layer_indices(base_model_cfg.model_id, [layer / 1.0])[0] if isinstance(layer, float) else layer
+    base_submodule = base_model.layers[base_layer]
+    ft_submodule = ft_model.layers[base_layer]
+    d_model = base_model.config.hidden_size
+
+    # Mixing weights: explicit, else proportional to dataset sizes (matches the disk path's
+    # size-proportional token allocation via calculate_samples_per_dataset).
+    if s_cfg.get("dataset_weights", None) is not None:
+        weights = list(s_cfg.dataset_weights)
+    else:
+        lengths = [
+            len(load_dataset_from_hub_or_local(c.id, split="train", name=c.subset))
+            for c in dataset_cfgs
+        ]
+        weights = calculate_samples_per_dataset(lengths, sum(lengths))
+    logger.info(
+        f"Streaming datasets {[c.name for c in dataset_cfgs]} with weights {weights}"
+    )
+
+    common = dict(
+        base_model=base_model,
+        ft_model=ft_model,
+        base_submodule=base_submodule,
+        ft_submodule=ft_submodule,
+        tokenizer=tokenizer,
+        d_model=d_model,
+        context_len=cfg.preprocessing.context_len if hasattr(cfg, "preprocessing") else 1024,
+        out_batch_size=training_cfg.batch_size,
+        n_ctxs=s_cfg.n_ctxs,
+        buffer_device=s_cfg.buffer_device,
+        ignore_first_n_tokens=cfg.model.ignore_first_n_tokens_per_sample_during_training,
+        mask_token_id=s_cfg.get("mask_token_id", None),
+    )
+
+    train_buffer = PairedActivationBuffer(
+        data=_weighted_text_stream(dataset_cfgs, tokenizer, "train", weights, seed=cfg.seed),
+        **common,
+    )
+
+    # Finite validation set: pull a fixed number of batches into a list (has len()).
+    val_buffer = PairedActivationBuffer(
+        data=_weighted_text_stream(dataset_cfgs, tokenizer, "validation", weights, seed=cfg.seed + 1),
+        **common,
+    )
+    n_val_batches = max(1, training_cfg.num_validation_samples // training_cfg.batch_size)
+    val_data = [next(val_buffer) for _ in range(n_val_batches)]
+    logger.info(f"Built {len(val_data)} streaming validation batches")
+
+    if method_cfg.datasets.normalization.enabled:
+        normalize_mean, normalize_std = train_buffer.compute_normalizer()
+    else:
+        normalize_mean, normalize_std = None, None
+
+    activation_dim = d_model
+    steps = math.ceil(training_cfg.num_samples * training_cfg.epochs / training_cfg.batch_size)
+    logger.info(f"Streaming training: {steps} steps (≈{training_cfg.num_samples} tokens × {training_cfg.epochs} epochs)")
+
+    return train_buffer, val_data, normalize_mean, normalize_std, activation_dim, steps

--- a/src/diffing/utils/dictionary/streaming.py
+++ b/src/diffing/utils/dictionary/streaming.py
@@ -25,28 +25,22 @@ Enable via the method config:
 When `enabled` is false (the default) nothing here runs and the disk path is unchanged.
 """
 
-from __future__ import annotations
-
 import math
 import random
-from typing import Iterator, List, Tuple
+from typing import Iterator, List, Optional, Tuple
 
 import torch
 from loguru import logger
 from omegaconf import DictConfig, open_dict
+from dictionary_learning.cache import ActivationCache
 
-from ..configs import get_model_configurations, get_dataset_configurations
-from ..model import load_model_from_config
+from ..activations import calculate_samples_per_dataset, get_layer_indices
+from ..configs import get_dataset_configurations, get_model_configurations
 from ..data import load_dataset_from_hub_or_local
-from ..activations import get_layer_indices, calculate_samples_per_dataset
+from ..model import load_model_from_config
 
-# nnsight tracing flags, matching dictionary_learning.cache / preprocessing.
+# nnsight tracing flags, matching dictionary_learning.cache and the preprocessing pipeline.
 tracer_kwargs = {"scan": False, "validate": False}
-
-
-def _get_out(submodule):
-    x = submodule.output
-    return x[0] if isinstance(x, tuple) else x
 
 
 class PairedActivationBuffer:
@@ -63,12 +57,12 @@ class PairedActivationBuffer:
 
     def __init__(
         self,
-        data: Iterator[str],
-        base_model,
-        ft_model,
-        base_submodule,
-        ft_submodule,
-        tokenizer,
+        data: Iterator[str],  # yields pre-templated training strings
+        base_model,  # nnsight StandardizedTransformer (base/normal)
+        ft_model,  # nnsight StandardizedTransformer (finetuned)
+        base_submodule,  # layer module of base_model to read, e.g. model.layers[L]
+        ft_submodule,  # layer module of ft_model to read
+        tokenizer,  # shared tokenizer
         d_model: int,
         context_len: int = 1024,
         refresh_batch_size: int = 64,
@@ -77,7 +71,7 @@ class PairedActivationBuffer:
         buffer_device: str = "cpu",
         ignore_first_n_tokens: int = 0,
         add_special_tokens: bool = True,
-        mask_token_id: int | None = None,
+        mask_token_id: Optional[int] = None,
     ):
         self.data = iter(data)
         self.base_model = base_model
@@ -116,12 +110,17 @@ class PairedActivationBuffer:
                 break
         return texts
 
-    def _trace_out(self, model, submodule, tokens):
+    def _trace_out(self, model, submodule, tokens) -> torch.Tensor:
         with torch.no_grad(), model.trace(tokens, **tracer_kwargs):
-            acts = _get_out(submodule).reshape(-1, self.d_model).save()
+            acts = (
+                ActivationCache.get_activations(submodule, "out")
+                .reshape(-1, self.d_model)
+                .save()
+            )
         return acts
 
-    def refresh(self):
+    def refresh(self) -> None:
+        """Drop consumed rows and recompute activations until the buffer is full."""
         self.activations = self.activations[~self.read]
         while len(self.activations) < self._capacity and not self._exhausted:
             texts = self._text_batch()
@@ -156,30 +155,32 @@ class PairedActivationBuffer:
             len(self.activations), dtype=torch.bool, device=self.buffer_device
         )
 
-    def __next__(self):
+    def __next__(self) -> torch.Tensor:
         with torch.no_grad():
             if (~self.read).sum() < self._capacity // 2:
                 self.refresh()
             unread = (~self.read).nonzero().squeeze(-1)
             if len(unread) == 0:
                 raise StopIteration("Activation stream exhausted")
-            perm = torch.randperm(len(unread), device=unread.device)[: self.out_batch_size]
-            idxs = unread[perm]
+            perm = torch.randperm(len(unread), device=unread.device)
+            idxs = unread[perm[: self.out_batch_size]]
             self.read[idxs] = True
             return self.activations[idxs]
 
-    def compute_normalizer(self, n_batches: int = 20) -> Tuple[torch.Tensor, torch.Tensor]:
-        """(mean, std) of shape [2, d] from an initial fill, for trainer_config."""
+    def compute_normalizer(
+        self, n_batches: int = 20
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Return (mean, std) of shape [2, d_model] from an initial fill of the buffer."""
         self.refresh()
         n = min(n_batches * self.out_batch_size, len(self.activations))
         sample = self.activations[:n].float()
         mean = sample.mean(dim=0)
         std = sample.std(dim=0, unbiased=False)
-        logger.info(f"Streaming normalizer from {n} rows -> shape {tuple(mean.shape)}")
+        logger.info(f"Computed streaming normalizer from {n} activations")
         return mean, std
 
     @property
-    def config(self):
+    def config(self) -> dict:
         return {
             "buffer_type": "PairedActivationBuffer",
             "d_model": self.d_model,
@@ -202,13 +203,14 @@ def _row_to_text(row, ds_cfg, tokenizer) -> str:
 
 
 def _weighted_text_stream(
-    dataset_cfgs, tokenizer, split: str, weights: List[float], seed: int
+    dataset_cfgs: List, tokenizer, split: str, weights: List[float], seed: int
 ) -> Iterator[str]:
-    """Infinite weighted-interleave generator over the datasets' text.
+    """
+    Infinite weighted-interleave generator over the datasets' text.
 
     Each dataset is cycled (reshuffled per pass); at every step a dataset is chosen with
-    probability proportional to `weights`. The stream never ends on its own — it is bounded
-    externally by the trainer's `steps`.
+    probability proportional to `weights`. The stream never ends on its own - it is
+    bounded externally by the trainer's `steps`.
     """
     datasets = [
         load_dataset_from_hub_or_local(c.id, split=split, name=c.subset)
@@ -227,21 +229,37 @@ def _weighted_text_stream(
     total = float(sum(weights))
     probs = [w / total for w in weights]
     while True:
-        g = rng.choices(gens, weights=probs, k=1)[0]
-        yield next(g)
+        gen = rng.choices(gens, weights=probs, k=1)[0]
+        yield next(gen)
 
 
-def setup_streaming_training(cfg: DictConfig, layer: int, device: str):
+def setup_streaming_training(
+    cfg: DictConfig, layer: int, device: str
+) -> Tuple[
+    PairedActivationBuffer,
+    List[torch.Tensor],
+    Optional[torch.Tensor],
+    Optional[torch.Tensor],
+    int,
+    int,
+]:
     """
     Build the streaming training data, validation data, normalizer, and step count.
 
+    Args:
+        cfg: Full configuration.
+        layer: Layer index to read activations from (absolute, or a [0, 1] fraction).
+        device: Device the crosscoder trains on (unused here; models use the streaming
+            config's base_device / ft_device).
+
     Returns:
-        (train_buffer, val_data, normalize_mean, normalize_std, activation_dim, steps)
-        - train_buffer: PairedActivationBuffer (iterable; pass as trainSAE `data`)
-        - val_data: list of [B, 2, d] tensors (finite; len() works, as trainSAE expects)
+        Tuple of (train_buffer, val_data, normalize_mean, normalize_std, activation_dim,
+        steps). train_buffer is a PairedActivationBuffer (pass as trainSAE `data`);
+        val_data is a finite list of [B, 2, d_model] tensors (so len() works, as
+        trainSAE's validation loop expects).
     """
     method_cfg = cfg.diffing.method
-    s_cfg = method_cfg.streaming
+    streaming_cfg = method_cfg.streaming
     training_cfg = method_cfg.training
 
     base_model_cfg, ft_model_cfg = get_model_configurations(cfg)
@@ -254,22 +272,23 @@ def setup_streaming_training(cfg: DictConfig, layer: int, device: str):
 
     # Place the two models on their configured devices (model-parallel by default).
     with open_dict(base_model_cfg):
-        base_model_cfg.device_map = s_cfg.base_device
+        base_model_cfg.device_map = streaming_cfg.base_device
     with open_dict(ft_model_cfg):
-        ft_model_cfg.device_map = s_cfg.ft_device
+        ft_model_cfg.device_map = streaming_cfg.ft_device
     base_model = load_model_from_config(base_model_cfg)
     ft_model = load_model_from_config(ft_model_cfg)
     tokenizer = base_model.tokenizer
 
-    base_layer = get_layer_indices(base_model_cfg.model_id, [layer / 1.0])[0] if isinstance(layer, float) else layer
-    base_submodule = base_model.layers[base_layer]
-    ft_submodule = ft_model.layers[base_layer]
+    if isinstance(layer, float):
+        layer = get_layer_indices(base_model_cfg.model_id, [layer])[0]
+    base_submodule = base_model.layers[layer]
+    ft_submodule = ft_model.layers[layer]
     d_model = base_model.config.hidden_size
 
-    # Mixing weights: explicit, else proportional to dataset sizes (matches the disk path's
-    # size-proportional token allocation via calculate_samples_per_dataset).
-    if s_cfg.get("dataset_weights", None) is not None:
-        weights = list(s_cfg.dataset_weights)
+    # Mixing weights: explicit if given, else proportional to dataset sizes (matching the
+    # disk path's size-proportional token allocation via calculate_samples_per_dataset).
+    if streaming_cfg.get("dataset_weights", None) is not None:
+        weights = list(streaming_cfg.dataset_weights)
     else:
         lengths = [
             len(load_dataset_from_hub_or_local(c.id, split="train", name=c.subset))
@@ -280,33 +299,40 @@ def setup_streaming_training(cfg: DictConfig, layer: int, device: str):
         f"Streaming datasets {[c.name for c in dataset_cfgs]} with weights {weights}"
     )
 
-    common = dict(
+    context_len = (
+        cfg.preprocessing.context_len if hasattr(cfg, "preprocessing") else 1024
+    )
+    buffer_kwargs = dict(
         base_model=base_model,
         ft_model=ft_model,
         base_submodule=base_submodule,
         ft_submodule=ft_submodule,
         tokenizer=tokenizer,
         d_model=d_model,
-        context_len=cfg.preprocessing.context_len if hasattr(cfg, "preprocessing") else 1024,
+        context_len=context_len,
         out_batch_size=training_cfg.batch_size,
-        n_ctxs=s_cfg.n_ctxs,
-        buffer_device=s_cfg.buffer_device,
+        n_ctxs=streaming_cfg.n_ctxs,
+        buffer_device=streaming_cfg.buffer_device,
         ignore_first_n_tokens=cfg.model.ignore_first_n_tokens_per_sample_during_training,
-        mask_token_id=s_cfg.get("mask_token_id", None),
+        mask_token_id=streaming_cfg.get("mask_token_id", None),
     )
 
     train_buffer = PairedActivationBuffer(
-        data=_weighted_text_stream(dataset_cfgs, tokenizer, "train", weights, seed=cfg.seed),
-        **common,
+        data=_weighted_text_stream(
+            dataset_cfgs, tokenizer, "train", weights, seed=cfg.seed
+        ),
+        **buffer_kwargs,
     )
 
-    # Finite validation set: pull a fixed number of batches into a list (has len()).
+    # Finite validation set: pull a fixed number of batches into a list (so len() works).
     val_buffer = PairedActivationBuffer(
-        data=_weighted_text_stream(dataset_cfgs, tokenizer, "validation", weights, seed=cfg.seed + 1),
-        **common,
+        data=_weighted_text_stream(
+            dataset_cfgs, tokenizer, "validation", weights, seed=cfg.seed + 1
+        ),
+        **buffer_kwargs,
     )
-    n_val_batches = max(1, training_cfg.num_validation_samples // training_cfg.batch_size)
-    val_data = [next(val_buffer) for _ in range(n_val_batches)]
+    num_val_batches = max(1, training_cfg.num_validation_samples // training_cfg.batch_size)
+    val_data = [next(val_buffer) for _ in range(num_val_batches)]
     logger.info(f"Built {len(val_data)} streaming validation batches")
 
     if method_cfg.datasets.normalization.enabled:
@@ -315,7 +341,12 @@ def setup_streaming_training(cfg: DictConfig, layer: int, device: str):
         normalize_mean, normalize_std = None, None
 
     activation_dim = d_model
-    steps = math.ceil(training_cfg.num_samples * training_cfg.epochs / training_cfg.batch_size)
-    logger.info(f"Streaming training: {steps} steps (≈{training_cfg.num_samples} tokens × {training_cfg.epochs} epochs)")
+    steps = math.ceil(
+        training_cfg.num_samples * training_cfg.epochs / training_cfg.batch_size
+    )
+    logger.info(
+        f"Streaming training for {steps} steps "
+        f"(~{training_cfg.num_samples} tokens x {training_cfg.epochs} epochs)"
+    )
 
     return train_buffer, val_data, normalize_mean, normalize_std, activation_dim, steps

--- a/src/diffing/utils/dictionary/streaming.py
+++ b/src/diffing/utils/dictionary/streaming.py
@@ -44,6 +44,17 @@ from ..model import load_model_from_config
 tracer_kwargs = {"scan": False, "validate": False}
 
 
+def _needs_special_tokens(text: str, tokenizer) -> bool:
+    """Whether to prepend special tokens (BOS) when tokenizing `text`.
+
+    Mirrors the disk path (activation_collection.py): add the BOS only if the text does
+    not already contain it. Chat-templated text usually embeds the BOS, so forcing
+    add_special_tokens=True there would double it.
+    """
+    bos = tokenizer.bos_token
+    return bos is None or bos not in text
+
+
 class PairedActivationBuffer:
     """
     Buffer of paired (base, ft) activations at one layer, refilled on the fly.
@@ -118,6 +129,24 @@ class PairedActivationBuffer:
                 break
         return texts
 
+    def _tokenize_batch(self, texts: List[str]):
+        """Tokenize a batch with a per-text special-tokens decision (matching the disk
+        path), then pad. HF batch tokenization takes a single add_special_tokens flag,
+        but the interleaved stream mixes chat (BOS embedded) and plain rows, so each
+        text is encoded individually and then padded together via tokenizer.pad (which
+        honors padding_side and returns the same BatchEncoding as batch tokenization).
+        """
+        encoded = [
+            self.tokenizer(
+                text,
+                max_length=self.context_len,
+                truncation=True,
+                add_special_tokens=_needs_special_tokens(text, self.tokenizer),
+            )
+            for text in texts
+        ]
+        return self.tokenizer.pad(encoded, padding=True, return_tensors="pt")
+
     def _trace_out(self, model, submodule, tokens) -> torch.Tensor:
         with torch.no_grad(), model.trace(tokens, **tracer_kwargs):
             acts = (
@@ -135,14 +164,7 @@ class PairedActivationBuffer:
             if not texts:
                 break
 
-            tokens = self.tokenizer(
-                texts,
-                max_length=self.context_len,
-                truncation=True,
-                padding=True,
-                return_tensors="pt",
-                add_special_tokens=self.add_special_tokens,
-            )
+            tokens = self._tokenize_batch(texts)
 
             mask = tokens["attention_mask"].clone()
             if self.ignore_first_n_tokens > 0:
@@ -186,7 +208,9 @@ class PairedActivationBuffer:
         idx = torch.randperm(len(self.activations), device=self.activations.device)[:n]
         sample = self.activations[idx].float()
         mean = sample.mean(dim=0)
-        std = sample.std(dim=0, unbiased=True)  # unbiased, matching PairedActivationCache
+        # Biased std, matching the disk path's combine_normalizer (training.py), which
+        # uses std(unbiased=False); the input scaling must be identical between paths.
+        std = sample.std(dim=0, unbiased=False)
         logger.info(f"Computed streaming normalizer from {n} activations")
         return mean, std
 
@@ -213,14 +237,31 @@ def _row_to_text(row, ds_cfg, tokenizer) -> str:
     return row[ds_cfg.text_column or "text"]
 
 
-def _estimate_tokens_per_row(dataset, ds_cfg, tokenizer, sample_size: int = 128) -> float:
-    """Estimate mean tokens per row by tokenizing an evenly-spaced sample."""
+def _estimate_tokens_per_row(
+    dataset, ds_cfg, tokenizer, context_len: int, sample_size: int = 128
+) -> float:
+    """Estimate mean tokens per row on an evenly-spaced sample.
+
+    Tokenizes exactly as the buffer does (truncated to context_len, per-text special
+    tokens) so the row->token conversion behind draw_weights reflects the actually
+    buffered tokens; otherwise long-row datasets are over-counted and the dataset mix
+    skews away from the target token fractions.
+    """
     n = min(sample_size, len(dataset))
     step = max(1, len(dataset) // n)
     counts = []
     for i in range(0, len(dataset), step):
         text = _row_to_text(dataset[i], ds_cfg, tokenizer)
-        counts.append(len(tokenizer(text, add_special_tokens=False)["input_ids"]))
+        counts.append(
+            len(
+                tokenizer(
+                    text,
+                    max_length=context_len,
+                    truncation=True,
+                    add_special_tokens=_needs_special_tokens(text, tokenizer),
+                )["input_ids"]
+            )
+        )
         if len(counts) >= n:
             break
     return sum(counts) / max(1, len(counts))
@@ -289,11 +330,13 @@ def setup_streaming_training(
 
     # Place the two models on their configured devices (model-parallel by default).
     # get_model_configurations returns ModelConfig dataclasses (not OmegaConf nodes),
-    # so device_map is set by direct attribute assignment.
+    # so device_map is set by direct attribute assignment. ignore_cache=True forces a
+    # fresh load: the model cache key omits device_map, so a model loaded earlier on a
+    # different device would otherwise be reused and silently break the base/ft split.
     base_model_cfg.device_map = streaming_cfg.base_device
     ft_model_cfg.device_map = streaming_cfg.ft_device
-    base_model = load_model_from_config(base_model_cfg)
-    ft_model = load_model_from_config(ft_model_cfg)
+    base_model = load_model_from_config(base_model_cfg, ignore_cache=True)
+    ft_model = load_model_from_config(ft_model_cfg, ignore_cache=True)
     tokenizer = base_model.tokenizer
 
     if isinstance(layer, float):
@@ -315,11 +358,15 @@ def setup_streaming_training(
     train_datasets = load_all(train_cfgs)
     val_datasets = load_all(val_cfgs)
 
+    context_len = (
+        cfg.preprocessing.context_len if hasattr(cfg, "preprocessing") else 1024
+    )
+
     # Mixing: draws are per-row but the target is a TOKEN ratio, so convert target token
     # fractions to per-row probabilities by dividing by mean tokens/row. dataset_weights
     # (if given) are target token fractions; else weight by each dataset's total tokens.
     mean_tokens = [
-        _estimate_tokens_per_row(ds, c, tokenizer)
+        _estimate_tokens_per_row(ds, c, tokenizer, context_len)
         for ds, c in zip(train_datasets, train_cfgs)
     ]
     if streaming_cfg.get("dataset_weights", None) is not None:
@@ -336,9 +383,6 @@ def setup_streaming_training(
         draw_weights if len(val_cfgs) == len(train_cfgs) else [1.0] * len(val_cfgs)
     )
 
-    context_len = (
-        cfg.preprocessing.context_len if hasattr(cfg, "preprocessing") else 1024
-    )
     buffer_kwargs = dict(
         base_model=base_model,
         ft_model=ft_model,
@@ -363,11 +407,16 @@ def setup_streaming_training(
 
     # Finite validation set: pull a fixed (small) number of batches into a list so that
     # trainSAE's `len(validation_data)` works without materializing millions of rows.
+    # Use batch_size * 4 to match the disk path's validation loader (training.py
+    # overwrite_batch_size); BatchTopK's sparsity threshold is batch-size dependent, so
+    # the val batch size must match for the metrics to be comparable. (Total val tokens
+    # are still a bounded approximation of the disk path's num_validation_samples.)
+    val_buffer_kwargs = {**buffer_kwargs, "out_batch_size": training_cfg.batch_size * 4}
     val_buffer = PairedActivationBuffer(
         data=_make_text_stream(
             val_datasets, val_cfgs, tokenizer, val_weights, seed=cfg.seed + 1
         ),
-        **buffer_kwargs,
+        **val_buffer_kwargs,
     )
     num_val_batches = streaming_cfg.get("num_val_batches", 50)
     val_data = [next(val_buffer) for _ in range(num_val_batches)]

--- a/src/diffing/utils/dictionary/training.py
+++ b/src/diffing/utils/dictionary/training.py
@@ -668,6 +668,7 @@ def train_crosscoder_for_layer(
         model, last_eval_logs = trainSAE(
             data=train_data,
             trainer_config=trainer_config,
+            steps=max_steps,  # required: the streaming buffer is infinite, so bound the loop
             validate_every_n_steps=validate_every_n_steps,
             validation_data=val_data,
             use_wandb=cfg.wandb.enabled,

--- a/src/diffing/utils/dictionary/training.py
+++ b/src/diffing/utils/dictionary/training.py
@@ -668,7 +668,7 @@ def train_crosscoder_for_layer(
         model, last_eval_logs = trainSAE(
             data=train_data,
             trainer_config=trainer_config,
-            steps=max_steps,  # required: the streaming buffer is infinite, so bound the loop
+            steps=max_steps,  # Required: the streaming buffer is infinite, so bound the loop
             validate_every_n_steps=validate_every_n_steps,
             validation_data=val_data,
             use_wandb=cfg.wandb.enabled,

--- a/src/diffing/utils/dictionary/training.py
+++ b/src/diffing/utils/dictionary/training.py
@@ -654,16 +654,22 @@ def train_crosscoder_for_layer(
         epoch_idx_per_step = None
 
         trainer_config = create_crosscoder_trainer_config(
-            cfg, layer_idx, activation_dim, device, normalize_mean, normalize_std, run_name
+            cfg,
+            layer_idx,
+            activation_dim,
+            device,
+            normalize_mean,
+            normalize_std,
+            run_name,
         )
         trainer_config["steps"] = max_steps
         validate_every_n_steps = cfg.diffing.method.training.validate_every_n_steps
 
         logger.info(f"Streaming training configuration: {trainer_config['wandb_name']}")
-        logger.info(f"Training steps: {max_steps}, validation every: {validate_every_n_steps}")
-        checkpoint_dir = (
-            f"{cfg.infrastructure.storage.checkpoint_dir}/{trainer_config['wandb_name']}"
+        logger.info(
+            f"Training steps: {max_steps}, validation every: {validate_every_n_steps}"
         )
+        checkpoint_dir = f"{cfg.infrastructure.storage.checkpoint_dir}/{trainer_config['wandb_name']}"
 
         model, last_eval_logs = trainSAE(
             data=train_data,

--- a/src/diffing/utils/dictionary/training.py
+++ b/src/diffing/utils/dictionary/training.py
@@ -635,6 +635,81 @@ def train_crosscoder_for_layer(
     """
     logger.info(f"Training crosscoder for layer {layer_idx}")
 
+    # Streaming path (opt-in): compute paired activations on the fly instead of reading a
+    # disk cache. Disabled by default -> the disk path below is unchanged.
+    streaming_enabled = OmegaConf.select(
+        cfg, "diffing.method.streaming.enabled", default=False
+    )
+    if streaming_enabled:
+        from .streaming import setup_streaming_training
+
+        (
+            train_data,
+            val_data,
+            normalize_mean,
+            normalize_std,
+            activation_dim,
+            max_steps,
+        ) = setup_streaming_training(cfg, layer_idx, device)
+        epoch_idx_per_step = None
+
+        trainer_config = create_crosscoder_trainer_config(
+            cfg, layer_idx, activation_dim, device, normalize_mean, normalize_std, run_name
+        )
+        trainer_config["steps"] = max_steps
+        validate_every_n_steps = cfg.diffing.method.training.validate_every_n_steps
+
+        logger.info(f"Streaming training configuration: {trainer_config['wandb_name']}")
+        logger.info(f"Training steps: {max_steps}, validation every: {validate_every_n_steps}")
+        checkpoint_dir = (
+            f"{cfg.infrastructure.storage.checkpoint_dir}/{trainer_config['wandb_name']}"
+        )
+
+        model, last_eval_logs = trainSAE(
+            data=train_data,
+            trainer_config=trainer_config,
+            validate_every_n_steps=validate_every_n_steps,
+            validation_data=val_data,
+            use_wandb=cfg.wandb.enabled,
+            wandb_entity=cfg.wandb.entity,
+            wandb_project="Diffing-Game-Crosscoder",
+            wandb_group=cfg.organism.name,
+            log_steps=50,
+            save_dir=checkpoint_dir,
+            save_steps=validate_every_n_steps,
+            run_wandb_finish=False,
+            epoch_idx_per_step=epoch_idx_per_step,
+            return_last_eval_logs=True,
+        )
+
+        wandb_link = None
+        hf_repo_id = None
+        if cfg.wandb.enabled:
+            wandb_link = wandb.run.get_url()
+            upload_config_to_wandb(cfg)
+            wandb.finish()
+        if cfg.diffing.method.upload.model:
+            hf_repo_id = push_dictionary_model(Path(checkpoint_dir) / "model_final.pt")
+
+        training_metrics = {
+            "layer": layer_idx,
+            "activation_dim": activation_dim,
+            "dictionary_size": trainer_config["dict_size"],
+            "training_steps": max_steps,
+            "lr": trainer_config["lr"],
+            "wandb_link": wandb_link,
+            "model_type": cfg.diffing.method.model.type,
+            "run_name": trainer_config["wandb_name"],
+            "hf_repo_id": hf_repo_id,
+            "training_mode": "crosscoder_streaming",
+            "last_eval_logs": {
+                k: v.item() if isinstance(v, torch.Tensor) else v
+                for k, v in last_eval_logs.items()
+            },
+        }
+        logger.info(f"Successfully trained streaming crosscoder for layer {layer_idx}")
+        return training_metrics, Path(checkpoint_dir) / "model_final.pt"
+
     # Setup training datasets
     train_dataset, val_dataset, epoch_idx_per_step, normalize_mean, normalize_std = (
         setup_training_datasets(

--- a/tests/utils/test_streaming.py
+++ b/tests/utils/test_streaming.py
@@ -1,0 +1,169 @@
+"""CPU unit tests for the streaming activation buffer.
+
+The GPU choke point (`_trace_out`) is monkeypatched with a deterministic fake whose
+activation value at every position equals the token id, so every buffered row is
+attributable to the exact token that produced it. A minimal fake tokenizer stands in for
+the HF one (the buffer only uses __call__, pad, bos_token and padding_side).
+"""
+
+import pytest
+import torch
+
+from diffing.utils.dictionary.streaming import (
+    PairedActivationBuffer,
+    _make_text_stream,
+    _needs_special_tokens,
+)
+
+D_MODEL = 4
+BOS_ID = 99
+
+
+class FakeTokenizer:
+    bos_token = "<bos>"
+    padding_side = "left"
+
+    def __call__(self, text, max_length=None, truncation=True, add_special_tokens=True):
+        ids = [int(w) for w in text.split()]
+        if truncation and max_length is not None:
+            ids = ids[:max_length]
+        if add_special_tokens:
+            ids = [BOS_ID] + ids
+        return {"input_ids": ids, "attention_mask": [1] * len(ids)}
+
+    def pad(self, encoded, padding=True, return_tensors="pt"):
+        longest = max(len(e["input_ids"]) for e in encoded)
+        ids, mask = [], []
+        for e in encoded:
+            n = longest - len(e["input_ids"])
+            if self.padding_side == "right":
+                ids.append(e["input_ids"] + [0] * n)
+                mask.append(e["attention_mask"] + [0] * n)
+            else:
+                ids.append([0] * n + e["input_ids"])
+                mask.append([0] * n + e["attention_mask"])
+        return {"input_ids": torch.tensor(ids), "attention_mask": torch.tensor(mask)}
+
+
+def fake_trace(dtype=torch.bfloat16, offset=0.0):
+    """Activation of token t at every dim = t + offset (base offset 0, ft offset 1000)."""
+
+    def _trace(self, model, submodule, tokens):
+        ids = tokens["input_ids"].reshape(-1).to(torch.float32) + offset
+        return ids.unsqueeze(-1).repeat(1, D_MODEL).to(dtype)
+
+    return _trace
+
+
+def make_buffer(monkeypatch, texts, dtype=torch.bfloat16, **kw):
+    monkeypatch.setattr(PairedActivationBuffer, "_trace_out",
+                        fake_trace(dtype), raising=True)
+    defaults = dict(
+        data=iter(texts), base_model=None, ft_model=None, base_submodule=None,
+        ft_submodule=None, tokenizer=FakeTokenizer(), d_model=D_MODEL,
+        context_len=8, refresh_batch_size=2, out_batch_size=4, n_ctxs=2,
+        buffer_device="cpu", ignore_first_n_tokens=0, add_special_tokens=True,
+    )
+    defaults.update(kw)
+    return PairedActivationBuffer(**defaults)
+
+
+def buffered_token_values(buf):
+    """The token ids reconstructed from the buffered activations (dim 0, base side)."""
+    return sorted(int(v) for v in buf.activations[:, 0, 0].float().tolist())
+
+
+def test_buffer_adopts_model_dtype_lazily(monkeypatch):
+    buf = make_buffer(monkeypatch, ["1 2 3", "4 5 6"], dtype=torch.bfloat16)
+    assert buf.activations.dtype == torch.float32          # empty scaffold
+    buf.refresh()
+    assert buf.activations.dtype == torch.bfloat16        # adopted at first fill
+    assert buf.activations.shape[1:] == (2, D_MODEL)
+
+
+def test_mask_token_and_ignore_first_are_dropped(monkeypatch):
+    buf = make_buffer(monkeypatch, ["1 2 3", "4 2 5"], mask_token_id=2,
+                      ignore_first_n_tokens=1)
+    buf.refresh()
+    vals = buffered_token_values(buf)
+    assert 2 not in vals                                   # mask_token_id rows dropped
+    assert BOS_ID not in vals                              # first token ignored
+    assert set(vals) == {1, 3, 4, 5}
+    # right-padding is forced when ignore_first_n_tokens > 0
+    assert buf.tokenizer.padding_side == "right"
+
+
+def test_padding_rows_never_buffered(monkeypatch):
+    buf = make_buffer(monkeypatch, ["1 2 3 4 5", "6"])    # second text heavily padded
+    buf.refresh()
+    vals = buffered_token_values(buf)
+    assert vals.count(0) == 0                              # attention-masked padding dropped
+    assert {1, 2, 3, 4, 5, 6}.issubset(set(vals))
+
+
+def test_next_yields_marks_read_and_exhausts(monkeypatch):
+    buf = make_buffer(monkeypatch, ["1 2 3", "4 5 6"], out_batch_size=3)
+    batch = next(buf)
+    assert batch.shape == (3, 2, D_MODEL)
+    assert int(buf.read.sum()) == 3
+    seen = 3
+    with pytest.raises(StopIteration):
+        while True:
+            seen += len(next(buf))
+    assert seen == 8                                       # 2 texts x (3 tokens + BOS)
+
+
+def test_base_and_ft_sides_kept_separate(monkeypatch):
+    calls = []
+
+    def side_trace(self, model, submodule, tokens):
+        offset = 0.0 if len(calls) % 2 == 0 else 1000.0    # base traced first, then ft
+        calls.append(offset)
+        ids = tokens["input_ids"].reshape(-1).to(torch.float32) + offset
+        return ids.unsqueeze(-1).repeat(1, D_MODEL)
+
+    monkeypatch.setattr(PairedActivationBuffer, "_trace_out", side_trace, raising=True)
+    buf = PairedActivationBuffer(
+        data=iter(["1 2"]), base_model=None, ft_model=None, base_submodule=None,
+        ft_submodule=None, tokenizer=FakeTokenizer(), d_model=D_MODEL,
+        context_len=8, refresh_batch_size=2, out_batch_size=4, n_ctxs=2)
+    buf.refresh()
+    assert (buf.activations[:, 1, 0] - buf.activations[:, 0, 0] == 1000).all()
+
+
+def test_normalizer_matches_manual_biased_std(monkeypatch):
+    buf = make_buffer(monkeypatch, ["1 2 3", "4 5 6"], dtype=torch.float32)
+    mean, std = buf.compute_normalizer(n_samples=10_000)
+    sample = buf.activations.float()
+    assert torch.allclose(mean, sample.mean(dim=0))
+    assert torch.allclose(std, sample.std(dim=0, unbiased=False))
+    assert mean.shape == (2, D_MODEL) and std.shape == (2, D_MODEL)
+
+
+def test_needs_special_tokens_mirrors_disk_path():
+    tok = FakeTokenizer()
+    assert _needs_special_tokens("plain text", tok)
+    assert not _needs_special_tokens("<bos> already templated", tok)
+
+
+def test_text_stream_is_weighted_and_seeded():
+    class DS(list):
+        pass
+
+    ds_a, ds_b = DS(["a"] * 50), DS(["b"] * 50)
+    cfg = type("C", (), {"is_chat": False, "text_column": None})()
+
+    import diffing.utils.dictionary.streaming as S
+    orig = S._row_to_text
+    S._row_to_text = lambda row, ds_cfg, tok: row
+    try:
+        stream = _make_text_stream([ds_a, ds_b], [cfg, cfg], FakeTokenizer(),
+                                   draw_weights=[3.0, 1.0], seed=7)
+        draws = [next(stream) for _ in range(2000)]
+        frac_a = draws.count("a") / len(draws)
+        assert 0.70 < frac_a < 0.80                        # ~3:1 weighting
+        stream2 = _make_text_stream([ds_a, ds_b], [cfg, cfg], FakeTokenizer(),
+                                    draw_weights=[3.0, 1.0], seed=7)
+        assert [next(stream2) for _ in range(50)] == draws[:50]   # seeded determinism
+    finally:
+        S._row_to_text = orig


### PR DESCRIPTION
**Principle:** Training a crosscoder currently requires preprocessing all activations to disk first. For my 200M token runs that is a few hundred GB and a long preprocessing step per experiment, which gets painful when iterating on model pairs. This adds an opt-in streaming path (diffing.method.streaming.enabled=true) that collects activations from the two models on the fly during training, with a paired buffer that keeps the sides aligned and handles refill, masking and normalization the same way the cached path does. The streaming block's device settings decide the placement: one GPU with both models and a CPU buffer is enough, two GPUs just splits the models. Default behavior is unchanged, and with streaming off nothing in the existing pipeline is touched.

**Code layout:** everything new lives in src/diffing/utils/dictionary/streaming.py (~400 lines), which implements PairedActivationBuffer: it pulls text from the same dataset the preprocessing step would use, runs both models batch by batch, grabs the target layer's activations through a single trace seam, and keeps a refillable buffer of paired (base, ft) activation rows in the models' dtype, with the same special-token masking and normalization the cache builder applies. training.py gets an ~80 line integration: when streaming.enabled is set it builds the buffer instead of loading cached activations, and training consumes it like any other dataset (max_steps honored, ft device auto-derived from the base device when unset). The config block in configs/diffing/method/crosscoder.yaml holds the enable flag and the three device settings. tests/utils/test_streaming.py covers the buffer on CPU with a fake tokenizer and a monkeypatched trace, so the tests run without GPUs or model downloads.

**Checks:** To check the two paths actually train the same thing, an automated test trained the same config twice (same pair, same data mix, 4M samples, x8/k50), once cached and once streamed, run on a single GPU, and compared the resulting dictionaries: the dec_norm_diff distributions match with quantile correlation 0.993 and a max quantile gap of 0.008, and the ft-leaning tails are identical. Latent counts at a fixed 0.6 cutoff do move between runs, but I believe that is a density spike of dead latents sitting right at the threshold on this small test dictionary, not a distribution difference. The buffer logic itself is covered by CPU unit tests (dtype adoption, masking, padding, refill and exhaustion, paired sides, normalizer, seeded weighted streams).