### PR TITLE
Base decoder probe for latent scaling

### DIFF
--- a/configs/diffing/method/crosscoder.yaml
+++ b/configs/diffing/method/crosscoder.yaml
@@ -65,6 +65,8 @@ analysis:
     device: "cuda"
     dtype: "float32"
     num_effective_ft_only_latents: 5000
+    compute_base_only: false  # Also probe with the base decoder (the ft probe cannot rank base-only latents)
+    num_effective_base_only_latents: 5000
     overwrite: false
 
   latent_activations: # Collect latent activations for all datasets and layers

--- a/src/diffing/utils/dictionary/latent_scaling/beta_analysis.py
+++ b/src/diffing/utils/dictionary/latent_scaling/beta_analysis.py
@@ -69,6 +69,20 @@ def update_latent_df_with_beta_values(
         df = add_possible_cols(df, shared_indices, shared_error_betas)
         df["shared_baseline_latent"] = False
         df.loc[shared_indices, "shared_baseline_latent"] = True
+    if Path(betas_dir / "effective_base_only_latents" / "indices.pt").exists():
+        base_specific_indices = th.load(
+            betas_dir / "effective_base_only_latents" / "indices.pt"
+        )
+        if isinstance(base_specific_indices, th.Tensor):
+            base_specific_indices = base_specific_indices.tolist()
+        base_probe_betas = load_betas_results(
+            betas_dir / "effective_base_only_latents",
+            configs,
+            num_samples=num_samples,
+        )
+        df = add_base_probe_cols(df, base_specific_indices, base_probe_betas)
+        df["effective_base_only_latent"] = False
+        df.loc[base_specific_indices, "effective_base_only_latent"] = True
     push_latent_df(df, crosscoder, confirm=False)
     return df
 
@@ -192,6 +206,49 @@ def add_possible_cols(df, indices, betas):
         )
         df["beta_activation_no_bias_ratio"] = (
             df["beta_activation_no_bias_base"] / df["beta_activation_no_bias_ft"]
+        )
+
+    return df
+
+
+def add_base_probe_cols(df, indices, betas):
+    """Add the base-probe (base-only pool) beta columns. Same betas files as
+    `add_possible_cols`, but computed with probe_decoder="base", so the columns get a
+    `_dbase` suffix. The ratios are other-model/own-model: beta_ft/beta_base -> 0 means
+    genuinely base-only, ~1 means the latent is actually present in both models."""
+    if (
+        betas["normal"]["base"]["error"] is not None
+        and betas["normal"]["ft"]["error"] is not None
+    ):
+        print("Adding beta_error_base_dbase and beta_error_ft_dbase")
+        df = add_col_to_df(
+            df, indices, "beta_error_base_dbase", betas["normal"]["base"]["error"]
+        )
+        df = add_col_to_df(
+            df, indices, "beta_error_ft_dbase", betas["normal"]["ft"]["error"]
+        )
+        df["beta_ratio_error_base_only"] = (
+            df["beta_error_ft_dbase"] / df["beta_error_base_dbase"]
+        )
+
+    if (
+        betas["normal"]["base"]["reconstruction"] is not None
+        and betas["normal"]["ft"]["reconstruction"] is not None
+    ):
+        df = add_col_to_df(
+            df,
+            indices,
+            "beta_reconstruction_base_dbase",
+            betas["normal"]["base"]["reconstruction"],
+        )
+        df = add_col_to_df(
+            df,
+            indices,
+            "beta_reconstruction_ft_dbase",
+            betas["normal"]["ft"]["reconstruction"],
+        )
+        df["beta_ratio_reconstruction_base_only"] = (
+            df["beta_reconstruction_ft_dbase"] / df["beta_reconstruction_base_dbase"]
         )
 
     return df

--- a/src/diffing/utils/dictionary/latent_scaling/closed_form.py
+++ b/src/diffing/utils/dictionary/latent_scaling/closed_form.py
@@ -405,6 +405,72 @@ def compute_scalers_from_config(
             shared_dir / "indices.pt",
         )
 
+    # Symmetric pass probing with the base decoder: the ft probe is degenerate for
+    # base-only latents (d_ft ~ 0), so score the top-K highest-dec_norm_diff pool with
+    # d_base instead; beta_ft/beta_base -> 0 marks base-only, ~1 shared.
+    compute_base_only = bool(ls_cfg.get("compute_base_only", False))
+    if compute_base_only and is_sae:
+        logger.warning("compute_base_only requires a CrossCoder; skipping for SAE runs")
+        compute_base_only = False
+    if compute_base_only:
+        base_pool_dir = (
+            results_dir / "closed_form_scalars" / "effective_base_only_latents"
+        )
+        base_targets = {
+            target: target in ls_cfg.targets
+            for target in [
+                "ft_error",
+                "base_error",
+                "ft_reconstruction",
+                "base_reconstruction",
+            ]
+        }
+        if not ls_cfg.overwrite:
+            for target in base_targets:
+                base_targets[target] = base_targets[target] and not betas_exist(
+                    base_pool_dir, num_samples, target
+                )
+        if any(base_targets.values()):
+            df_base = load_latent_df(dictionary_model)
+            num_base_only = int(
+                ls_cfg.get(
+                    "num_effective_base_only_latents", num_effective_ft_only_latents
+                )
+            )
+            if num_base_only == -1:
+                base_only_indices = df_base.query("tag == 'base_only'").index.tolist()
+            else:
+                base_only_indices = (
+                    df_base.sort_values(by="dec_norm_diff", ascending=False)
+                    .head(num_base_only)
+                    .index.tolist()
+                )
+            logger.info(
+                f"Computing base-probe scalars {[t for t, v in base_targets.items() if v]} "
+                f"for {len(base_only_indices)} effective base-only latents"
+            )
+            compute_scalers(
+                dataset=dataset,
+                dictionary_model=dictionary_model,
+                results_dir=results_dir,
+                latent_indices=th.tensor(base_only_indices),
+                latent_indices_name="effective_base_only_latents",
+                num_samples=num_samples,
+                ft_error=base_targets["ft_error"],
+                base_error=base_targets["base_error"],
+                ft_reconstruction=base_targets["ft_reconstruction"],
+                base_reconstruction=base_targets["base_reconstruction"],
+                is_sae=is_sae,
+                sae_model=sae_model,
+                is_difference_sae=is_difference_sae,
+                smaller_batch_size_for_error=True,
+                batch_size=ls_cfg.batch_size,
+                num_workers=ls_cfg.num_workers,
+                probe_decoder="base",
+            )
+            base_pool_dir.mkdir(parents=True, exist_ok=True)
+            th.save(base_only_indices, base_pool_dir / "indices.pt")
+
 
 def compute_scalers(
     dataset: ActivationCache,
@@ -438,6 +504,7 @@ def compute_scalers(
     is_difference_sae: bool = False,
     sae_model: Literal["base", "chat"] | None = None,
     smaller_batch_size_for_error: bool = False,
+    probe_decoder: Literal["ft", "base"] = "ft",
 ) -> None:
     """
     Compute closed-form scalars (betas) for latent scaling analysis.
@@ -485,6 +552,11 @@ def compute_scalers(
         is_difference_sae: Whether the dictionary is a difference SAE (default: False)
         sae_model: Which model to use for SAE ("base" or "chat") (default: None)
         smaller_batch_size_for_error: Use 8x smaller batch size for error computations to reduce memory usage (default: False)
+        probe_decoder: Which decoder supplies the probe directions regressed onto the targets
+            (default: "ft", the historical behaviour). "base" probes with the base decoder —
+            used to score base-only candidate latents, for which the ft decoder is ~0 and
+            therefore a degenerate probe. Error-target removal terms always stay each model's
+            OWN decoder regardless of the probe. "base" requires a CrossCoder.
 
     Returns:
         None (saves results to disk)
@@ -640,9 +712,25 @@ def compute_scalers(
             ("ft_reconstruction", partial(load_ft_reconstruction, normalize=True))
         )
     if ft_error:
-        computations.append(("ft_error", partial(load_ft_error, normalize=True)))
+        # With a base probe, the ft-error removal must stay the ft model's own decoder
+        computations.append(
+            (
+                "ft_error",
+                partial(
+                    load_ft_error,
+                    ft_decoder=ft_decoder if probe_decoder == "base" else None,
+                    normalize=True,
+                ),
+            )
+        )
 
-    latent_vectors = ft_decoder[latent_indices].clone()
+    if probe_decoder == "base":
+        assert isinstance(
+            dict_model, CrossCoder
+        ), "probe_decoder='base' only makes sense for a CrossCoder (an SAE has a single decoder)"
+        latent_vectors = base_decoder[latent_indices].clone()
+    else:
+        latent_vectors = ft_decoder[latent_indices].clone()
     if random_vectors:
         random_vectors = th.randn(
             len(latent_indices), dict_model.activation_dim, device=device

--- a/src/diffing/utils/dictionary/latent_scaling/closed_form.py
+++ b/src/diffing/utils/dictionary/latent_scaling/closed_form.py
@@ -268,7 +268,33 @@ def compute_scalers_from_config(
 
     logger.info(f"Scalers to compute: {scalers_to_compute}")
 
-    if len(scalers_to_compute) == 0:
+    # The base-probe pass may still be pending even when every ft-probe target exists
+    # (e.g. resuming a finished run with compute_base_only newly enabled).
+    base_only_pending = (
+        bool(ls_cfg.get("compute_base_only", False))
+        and not is_sae
+        and any(
+            target in ls_cfg.targets
+            and (
+                ls_cfg.overwrite
+                or not betas_exist(
+                    results_dir
+                    / "closed_form_scalars"
+                    / "effective_base_only_latents",
+                    num_samples,
+                    target,
+                )
+            )
+            for target in (
+                "ft_error",
+                "base_error",
+                "ft_reconstruction",
+                "base_reconstruction",
+            )
+        )
+    )
+
+    if len(scalers_to_compute) == 0 and not base_only_pending:
         logger.info("No scalers to compute, exiting")
         return
 

--- a/src/diffing/utils/dictionary/latent_scaling/utils.py
+++ b/src/diffing/utils/dictionary/latent_scaling/utils.py
@@ -148,9 +148,15 @@ def load_ft_error(
     latent_activations: th.Tensor,
     latent_indices: th.Tensor,
     latent_vectors: th.Tensor,
+    ft_decoder: th.Tensor | None = None,
     normalize: bool = False,
     **kwargs,
 ):
+    """ft_decoder: removal directions for the ft error target. Defaults to `latent_vectors`
+    (the probe), which is correct when probing with the ft decoder. When probing with another
+    direction (e.g. the base decoder), pass the full ft decoder so the removal term stays the
+    ft model's own directions (mirror of `load_base_error`'s explicit `base_decoder`).
+    """
     assert isinstance(crosscoder, CrossCoder) or isinstance(
         crosscoder, BatchTopKCrossCoder
     ), "ft error requires a crosscoder"
@@ -159,7 +165,9 @@ def load_ft_error(
     )
     normalized_batch = identity_fn(batch, crosscoder, normalize)
     return normalized_batch[:, 1, :] - remove_latents(
-        reconstruction[:, 1, :], latent_activations[:, latent_indices], latent_vectors
+        reconstruction[:, 1, :],
+        latent_activations[:, latent_indices],
+        latent_vectors if ft_decoder is None else ft_decoder[latent_indices],
     )
 
 

--- a/tests/utils/test_latent_scaling.py
+++ b/tests/utils/test_latent_scaling.py
@@ -275,5 +275,103 @@ class TestClosedFormScalars:
         )
 
 
+class _TwoModelToyCrosscoder(CrossCoder):
+    """Minimal two-decoder crosscoder with exact linear decode and ground-truth codes.
+    decoder_weight: (2, dict_size, dim_model); encode() replays the ground-truth codes
+    batch by batch (same trick as ToyCrosscoder above)."""
+
+    def __init__(self, decoder_weight: th.Tensor, codes_batched: th.Tensor):
+        self.decoder_weight = decoder_weight
+        self.codes_batched = codes_batched
+        self.dict_size = decoder_weight.shape[1]
+        self.batch_index = 0
+
+    def encode(self, x: th.Tensor, **kwargs) -> th.Tensor:
+        out = self.codes_batched[self.batch_index % self.codes_batched.shape[0]]
+        self.batch_index += 1
+        return out
+
+    def decode(self, f: th.Tensor, denormalize_activations: bool = False) -> th.Tensor:
+        # (N, dict) @ (2, dict, dim) -> (N, 2, dim)
+        return th.einsum("nd,ldm->nlm", f, self.decoder_weight)
+
+
+def _make_two_model_world(dtype=th.float64, seed=0):
+    """4 orthogonal latent directions with known per-model decoder scales:
+    latent 0 base-only (d_ft = 0), latent 1 shared equal, latent 2 ft weaker (0.25x
+    relative to base along the same direction), latent 3 ft stronger (3x). Activations
+    are decoded EXACTLY, so the per-latent error target after own-decoder removal is
+    f_j * d_j^model and every beta is analytic."""
+    th.manual_seed(seed)
+    M, D, NB, BS = 32, 4, 4, 50
+    dirs = th.linalg.qr(th.randn(M, D, dtype=dtype))[0].T  # (D, M) orthonormal
+    base_scale = th.tensor([1.0, 1.0, 2.0, 0.5], dtype=dtype)
+    ft_scale = th.tensor([0.0, 1.0, 0.5, 1.5], dtype=dtype)
+    W = th.stack([dirs * base_scale[:, None], dirs * ft_scale[:, None]])  # (2, D, M)
+    codes = th.randn(NB, BS, D, dtype=dtype).exp()  # dense positive codes
+    batches = th.einsum("nbd,ldm->nblm", codes, W)  # (NB, BS, 2, M) exact decode
+    expected_nu = ft_scale / base_scale  # probe d_base: beta_ft/beta_base = scale ratio
+    return W, codes, batches, expected_nu
+
+
+class TestBaseProbe:
+    """CPU tests for the base-decoder probe path (base-only latent scaling)."""
+
+    def test_load_ft_error_ft_decoder_kwarg(self):
+        from diffing.utils.dictionary.latent_scaling.utils import load_ft_error
+
+        W, codes, batches, _ = _make_two_model_world()
+        cc = _TwoModelToyCrosscoder(W, codes)
+        idx = th.arange(W.shape[1])
+        batch, f = batches[0], codes[0]
+
+        legacy = load_ft_error(batch, cc, f, idx, latent_vectors=W[1][idx])
+        with_kwarg = load_ft_error(
+            batch, cc, f, idx, latent_vectors=W[0][idx], ft_decoder=W[1]
+        )
+        # Removal must be probe-independent when ft_decoder is given
+        assert th.allclose(legacy, with_kwarg)
+        # ...and the kwarg must actually matter: base-probe removal without it differs
+        wrong_removal = load_ft_error(batch, cc, f, idx, latent_vectors=W[0][idx])
+        assert not th.allclose(legacy, wrong_removal)
+
+    def test_base_probe_nu_separates_base_only_latents(self):
+        """End-to-end through closed_form_scalars: probing with d_base, the error-beta
+        ratio beta_ft/beta_base must be 0 for a base-only latent, 1 for a shared one,
+        and the exact decoder-scale ratio in between."""
+        from functools import partial
+        from diffing.utils.dictionary.latent_scaling.utils import (
+            load_base_error,
+            load_ft_error,
+        )
+
+        W, codes, batches, expected_nu = _make_two_model_world()
+        idx = th.arange(W.shape[1])
+        probe = W[0][idx].clone()  # base decoder = the probe
+        device = th.device("cpu")
+
+        betas_base, *_ = closed_form_scalars(
+            probe,
+            idx,
+            batches,
+            _TwoModelToyCrosscoder(W, codes),
+            partial(load_base_error, base_decoder=W[0], normalize=False),
+            device=device,
+            dtype=th.float64,
+        )
+        betas_ft, *_ = closed_form_scalars(
+            probe,
+            idx,
+            batches,
+            _TwoModelToyCrosscoder(W, codes),
+            partial(load_ft_error, ft_decoder=W[1], normalize=False),
+            device=device,
+            dtype=th.float64,
+        )
+        assert th.allclose(betas_base, th.ones_like(betas_base))
+        nu = betas_ft / betas_base
+        assert th.allclose(nu, expected_nu)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
**Issue and solution:** latent_vectors in compute_scalers is hardcoded to the ft decoder, so latent scaling can only score ft-leaning latents. There is no way to get the ν ratios for base-only latents without reimplementing the whole error path outside the toolkit, which is what I had been doing. This adds an opt-in base-decoder probe: same machinery, same settings, just the other decoder side and a base-leaning pool. Defaults unchanged.

**Also includes a small fix**: when only the base-probe pass is pending on an otherwise finished run, the "no scalers to compute" early exit skipped it.

**Code implementation:** mostly latent_scaling/closed_form.py: compute_scalers_from_config gains a base-probe pass that mirrors the existing ft one, building a base-leaning pool from dec_norm_diff the same way the ft pool is built, probing with the base decoder rows instead of the hardcoded ft side, and running the same closed_form_scalars error and reconstruction targets, with the betas saved under their own pool directory so nothing collides with existing outputs. beta_analysis.py assembles the ν ratios for the base pool from those betas, utils.py gets a couple of shared helpers, and the config grows one opt-in flag under analysis.latent_scaling. The early-exit fix is in the same file: the pending check now considers a base-only pass that still needs computing on an otherwise finished run. tests/utils/test_latent_scaling.py covers the pool construction and the pending logic.

**Checks:** To make sure the refactor didn't change the existing path, an automated test recomputed the production betas of my 200M run on this branch and compared against the stored values: 4997 of 5000 latents agree to 4e-15 or better across the base_error, ft_rec and ft_error targets, which is bit-level reproduction up to float noise.